### PR TITLE
Feat(gdt.h, gdt.c, ltr_asm.S): initialize segment descriptors and task register

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ SRC   := src
 OBJS :=	$(BUILD)/boot.o \
 	$(BUILD)/kernel.o \
 	$(BUILD)/gdt.o \
-	$(BUILD)/lgdt_asm.o
+	$(BUILD)/lgdt_asm.o \
+	$(BUILD)/ltr_asm.o
 
 .PHONY: all clean iso run
 
@@ -31,6 +32,9 @@ $(BUILD)/gdt.o: $(SRC)/kernel/gdt.c | $(BUILD)
 
 $(BUILD)/lgdt_asm.o: $(SRC)/kernel/lgdt_asm.S | $(BUILD)
 	$(AS) --64 $(SRC)/kernel/lgdt_asm.S -o $@
+
+$(BUILD)/ltr_asm.o: $(SRC)/kernel/ltr_asm.S | $(BUILD)
+	$(AS) --64 $(SRC)/kernel/ltr_asm.S -o $@
 
 $(BUILD):
 	mkdir -p $(BUILD)

--- a/src/kernel/gdt.c
+++ b/src/kernel/gdt.c
@@ -1,14 +1,16 @@
 #include "gdt.h"
 
 extern void gdtr_load(uint64_t gdtr_address);
+extern void tss_load(uint16_t tss_address);
 
-struct gdt_entry gdt[5];
-struct gdt_ptr gdtr;
+struct GDT_ENTRY	gdt_entry[7];
+struct TSS_ENTRY	tss_entry;
+struct GDTR		gdtr;
 
 void gdtr_init(void) {
 	// Define 10 Bytes GDTR Structure
-	gdtr.limit = (sizeof(struct gdt_entry) * 5) - 1;	// 39 Bytes
-	gdtr.base = (uint64_t)&gdt;
+	gdtr.limit = (sizeof(struct GDT_ENTRY) * 7) - 1;	// 39 Bytes
+	gdtr.base = (uint64_t)&gdt_entry;
 
 	/*
 	 * Define each Segment Descriptor
@@ -25,19 +27,57 @@ void gdtr_init(void) {
 	gdt_set_entry(3, 0, 0xFFFFFFFF, 0xC0, 0xF2);
 	// GDT[4]
 	gdt_set_entry(4, 0, 0xFFFFFFFF, 0xA0, 0xFA);
+	// GDT[5] == TSS[0]
+	// GDT[6] == TSS[1]
+	gdt_tss_descriptor_set_entry(5, (uint64_t)&tss_entry, sizeof(struct TSS_ENTRY) - 1, 0x89, 0x00);
+
+	// Initialize TSS Structure
+	tss_set_entry(&tss_entry);
+	// We need to fill real stack address into TSS Structure's Entries
+	
+	// Between here
+
 
 	// GDTR load and segment register update
 	gdtr_load((uint64_t)&gdtr);
+
+	// Register the TSS descriptor (GDT index 5) into the CPU's Task Register
+	tss_load(0x28);	// The 5th Descriptor in GDT. 5 * 8(Bytes) = 40 = 0x28
 }
 
 void gdt_set_entry(int idx, uint32_t base, uint32_t limit, uint8_t access, uint8_t attributes) {
-	gdt[idx].base_low    = (base & 0xFFFF);
-	gdt[idx].base_mid    = (base >> 16) & 0xFF;
-	gdt[idx].base_high   = (base >> 24) & 0xFF;
+	gdt_entry[idx].base_low    = (base & 0xFFFF);
+	gdt_entry[idx].base_mid    = (base >> 16) & 0xFF;
+	gdt_entry[idx].base_high   = (base >> 24) & 0xFF;
 
-	gdt[idx].limit_low   = (limit & 0xFFFF);
-	gdt[idx].attributes  = (limit >> 16) & 0x0F;	// limit_high
+	gdt_entry[idx].limit_low   = (limit & 0xFFFF);
+	gdt_entry[idx].attributes  = (limit >> 16) & 0x0F;	// limit_high
 
-	gdt[idx].attributes |= (attributes & 0xF0);
-	gdt[idx].access      = (access);
+	gdt_entry[idx].attributes |= (attributes & 0xF0);
+	gdt_entry[idx].access      = (access);
+}
+
+void tss_set_entry(struct TSS_ENTRY* tss_entry_ptr) {
+	for (size_t i = 0; i < sizeof(struct TSS_ENTRY); i++) {
+		((char*)tss_entry_ptr)[i] = 0;
+	}
+}
+
+void gdt_tss_descriptor_set_entry(int idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t attributes) {
+	gdt_entry[idx].base_low		= (base & 0xFFFF);
+	gdt_entry[idx].base_mid		= (base >> 16) & 0xFF;
+	gdt_entry[idx].base_high	= (base >> 24) & 0xFF;
+	gdt_entry[idx + 1].limit_low	= (base >> 32) & 0xFFFF;
+	gdt_entry[idx + 1].base_low	= (base >> 48) & 0xFFFF;
+
+	gdt_entry[idx].limit_low	= (limit & 0xFFFF);
+	gdt_entry[idx].attributes	= (limit >> 16) & 0x0F;
+
+	gdt_entry[idx].attributes      |= (attributes & 0xF0);
+	gdt_entry[idx].access		= (access);
+
+	gdt_entry[idx + 1].base_mid	= 0;
+	gdt_entry[idx + 1].access	= 0;
+	gdt_entry[idx + 1].attributes	= 0;
+	gdt_entry[idx + 1].base_high	= 0;
 }

--- a/src/kernel/gdt.h
+++ b/src/kernel/gdt.h
@@ -2,9 +2,10 @@
 #define GDT_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 // Segment Descriptor Structure
-struct gdt_entry {
+struct GDT_ENTRY {
 	uint16_t	limit_low;
 	uint16_t	base_low;
 	uint8_t		base_mid;
@@ -13,14 +14,35 @@ struct gdt_entry {
 	uint8_t		base_high;
 } __attribute__((packed));
 
+struct TSS_ENTRY {
+	uint32_t reserved1;
+	uint64_t rsp0;
+	uint64_t rsp1;
+	uint64_t rsp2;
+	uint64_t reserved2;
+	uint64_t ist1;
+	uint64_t ist2;
+	uint64_t ist3;
+	uint64_t ist4;
+	uint64_t ist5;
+	uint64_t ist6;
+	uint64_t ist7;
+	uint64_t reserved3;
+	uint16_t reserved4;
+	uint16_t iopb;
+} __attribute__((packed));
+
 // GDTR Structure
-struct gdt_ptr {
+struct GDTR {
 	uint16_t	limit;
 	uint64_t	base;
 } __attribute__((packed));
 
 void gdtr_init(void);
 void gdt_set_entry(int idx, uint32_t base, uint32_t limit, uint8_t access, uint8_t attributes);
-void gdtr_load(uint64_t gdtr_address);
+void tss_set_entry(struct TSS_ENTRY* tss_entry_ptr);
+void gdt_tss_descriptor_set_entry(int idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t attributes);
+extern void gdtr_load(uint64_t gdtr_address);
+extern void tss_load(uint16_t tss_address);
 
 #endif

--- a/src/kernel/ltr_asm.S
+++ b/src/kernel/ltr_asm.S
@@ -1,0 +1,11 @@
+.intel_syntax noprefix
+.code64
+
+.global tss_load
+
+.section .text
+
+tss_load:
+	ltr di
+
+	ret


### PR DESCRIPTION
- add TSS Descriptor in GDT ("gdt.c")
- add 104 Bytes TSS Structure ("gdt.h")
- add <stddef.h> to use 'size_t' ("gdt.h")
- add two functions to initialize TSS Structure, TSS Descriptor ("gdt.h", "gdt.c")
- add ltr_asm.S to register the index of TSS Descriptor into CPU's register ("ltr_asm.S")
- edit Makefile to "make run"

- ps. TSS 구조체 정의는 해놨고 내부는 'tss_set_entry' 함수로 다 0으로 초기화시켰음. 이제 ist 초기화하려면 'tss_set_entry' 함수랑 'load_gdtr' 함수 사이에서 스택 주소들 넣어주면 됨.