### PR TITLE
feat/refactor(gdt.c, gdt.h): add IST1, IST2 & refactor functions

### DIFF
--- a/src/arch/x86_64/gdt/gdt.c
+++ b/src/arch/x86_64/gdt/gdt.c
@@ -2,44 +2,60 @@
 #include <stddef.h>
 #include <gdt.h>
 
+struct GDT_ENTRY	gdt_entry[7];	// GDT
+struct TSS_ENTRY	tss_entry;	// TSS == *GDT[5:6]
+struct GDTR		gdtr;		// GDTR == *GDT
+
+static uint8_t fault_stack[4096] __attribute((aligned(16)));	// IST1
+static uint8_t debug_stack[4096] __attribute((aligned(16)));	// IST2
+
 extern void gdtr_load(uint64_t gdtr_address);
 extern void tss_load(uint16_t tss_address);
 
-struct GDT_ENTRY	gdt_entry[7];
-struct TSS_ENTRY	tss_entry;
-struct GDTR		gdtr;
-
-void gdt_init(void) {
+void init_arch_tables(void) {
 	// Define 10 Bytes GDTR Structure
 	gdtr.limit = (sizeof(struct GDT_ENTRY) * 7) - 1;	// 39 Bytes
 	gdtr.base = (uint64_t)&gdt_entry;
 
+	setup_gdt();
+	setup_tss();
+	load_cpu_registers();
+}
+
+void setup_gdt(void) {
 	/*
 	 * Define each Segment Descriptor
 	 * The value of the 0th Segment Descriptor is always all 0.
 	 * All Segment Descriptor have a base address of 0 and a segment limit of 0xFFFFFFFF.
 	 */
+
 	// GDT[0]
-	gdt_set_entry(0, 0, 0, 0, 0);
+	gdt_set_entry(0, 0, 0, 0 ,0);
 	// GDT[1]
-	gdt_set_entry(1, 0, 0xFFFFFFFF, 0x9A, 0xA0);
+	gdt_set_entry(1, 0, 0xFFFFFFFF, 0xA0, 0x9A);
 	// GDT[2]
-	gdt_set_entry(2, 0, 0xFFFFFFFF, 0x92, 0xC0);
+	gdt_set_entry(2, 0, 0xFFFFFFFF, 0xC0, 0x92);
 	// GDT[3]
-	gdt_set_entry(3, 0, 0xFFFFFFFF, 0xF2, 0xC0);
+	gdt_set_entry(3, 0, 0xFFFFFFFF, 0xC0, 0xF2);
 	// GDT[4]
-	gdt_set_entry(4, 0, 0xFFFFFFFF, 0xFA, 0xA0);
-	// GDT[5] == TSS[0]
-	// GDT[6] == TSS[1]
-	gdt_tss_descriptor_set_entry(5, (uint64_t)&tss_entry, sizeof(struct TSS_ENTRY) - 1, 0x89, 0x00);
+	gdt_set_entry(4, 0, 0xFFFFFFFF, 0xA0, 0xFA);
+}
+
+void setup_tss(void) {
+	// GDT[5:6] (TSS Descriptor)
+	tss_set_entry(5, (uint64_t)&tss_entry, sizeof(struct TSS_ENTRY) - 1, 0x00, 0x89);
 
 	// Initialize TSS Structure
-	tss_set_entry(&tss_entry);
-	// We need to fill real stack address into TSS Structure's Entries
-	
-	// Between here
+	for (size_t i = 0; i < sizeof(struct TSS_ENTRY); i++) {
+		((char*)&tss_entry)[i] = 0;
+	}
 
+	// Fill real stack address into TSS Structure's Entries
+	tss_entry.ist1 = (uint64_t)fault_stack + sizeof(fault_stack);
+	tss_entry.ist2 = (uint64_t)debug_stack + sizeof(debug_stack);
+}
 
+void load_cpu_registers(void) {
 	// GDTR load and segment register update
 	gdtr_load((uint64_t)&gdtr);
 
@@ -47,7 +63,7 @@ void gdt_init(void) {
 	tss_load(0x28);	// The 5th Descriptor in GDT. 5 * 8(Bytes) = 40 = 0x28
 }
 
-void gdt_set_entry(int idx, uint32_t base, uint32_t limit, uint8_t access, uint8_t attributes) {
+void gdt_set_entry(int idx, uint32_t base, uint32_t limit, uint8_t flags, uint8_t access) {
 	gdt_entry[idx].base_low    = (base & 0xFFFF);
 	gdt_entry[idx].base_mid    = (base >> 16) & 0xFF;
 	gdt_entry[idx].base_high   = (base >> 24) & 0xFF;
@@ -55,17 +71,11 @@ void gdt_set_entry(int idx, uint32_t base, uint32_t limit, uint8_t access, uint8
 	gdt_entry[idx].limit_low   = (limit & 0xFFFF);
 	gdt_entry[idx].attributes  = (limit >> 16) & 0x0F;	// limit_high
 
-	gdt_entry[idx].attributes |= (attributes & 0xF0);
+	gdt_entry[idx].attributes |= (flags & 0xF0);
 	gdt_entry[idx].access      = (access);
 }
 
-void tss_set_entry(struct TSS_ENTRY* tss_entry_ptr) {
-	for (size_t i = 0; i < sizeof(struct TSS_ENTRY); i++) {
-		((char*)tss_entry_ptr)[i] = 0;
-	}
-}
-
-void gdt_tss_descriptor_set_entry(int idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t attributes) {
+void tss_set_entry(int idx, uint64_t base, uint32_t limit, uint8_t flags, uint8_t access) {
 	gdt_entry[idx].base_low		= (base & 0xFFFF);
 	gdt_entry[idx].base_mid		= (base >> 16) & 0xFF;
 	gdt_entry[idx].base_high	= (base >> 24) & 0xFF;
@@ -75,7 +85,7 @@ void gdt_tss_descriptor_set_entry(int idx, uint64_t base, uint32_t limit, uint8_
 	gdt_entry[idx].limit_low	= (limit & 0xFFFF);
 	gdt_entry[idx].attributes	= (limit >> 16) & 0x0F;
 
-	gdt_entry[idx].attributes      |= (attributes & 0xF0);
+	gdt_entry[idx].attributes      |= (flags & 0xF0);
 	gdt_entry[idx].access		= (access);
 
 	gdt_entry[idx + 1].base_mid	= 0;

--- a/src/include/gdt.h
+++ b/src/include/gdt.h
@@ -38,10 +38,12 @@ struct GDTR {
 	uint64_t	base;
 } __attribute__((packed));
 
-void gdt_init(void);
-void gdt_set_entry(int idx, uint32_t base, uint32_t limit, uint8_t access, uint8_t attributes);
-void tss_set_entry(struct TSS_ENTRY* tss_entry_ptr);
-void gdt_tss_descriptor_set_entry(int idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t attributes);
+void init_arch_tables(void);
+void setup_gdt(void);
+void setup_tss(void);
+void load_cpu_registers(void);
+void gdt_set_entry(int idx, uint32_t base, uint32_t limit, uint8_t flags, uint8_t access);
+void tss_set_entry(int idx, uint64_t base, uint32_t limit, uint8_t flags, uint8_t access);
 extern void gdtr_load(uint64_t gdtr_address);
 extern void tss_load(uint16_t tss_address);
 

--- a/src/kernel/kmain.c
+++ b/src/kernel/kmain.c
@@ -33,7 +33,7 @@ static void serial_write(const char* s) {
 /* Called from boot.s with Multiboot2 magic in RDI, info physical addr in RSI */
 void kmain(uint32_t multiboot_magic, uint32_t multiboot_info) {
     (void)multiboot_info; /* use later for memory map, cmdline, etc. */
-    gdt_init();
+    init_arch_tables();
     serial_init();
     serial_write("Hello from x86_64 kernel!\r\n");
     if (multiboot_magic == 0x36d76289) {


### PR DESCRIPTION
- Add **IST1 (Fault Stack)** and **IST2 (Debug Stack)** for stable exception handling
- Ensure **16-byte alignment** for all IST stacks to meet x86_64 requirements
- Rename **gdt_init** to **init_arch_tables** for better architectural clarity
- Decompose complex logic into **setup_gdt**, **setup_tss**, and **load_cpu_registers**
- Change the call to **gdt_init()** to call **init_arch_tables()**