### PR TITLE
Add decimal and size formatting functions for serial output

### DIFF
--- a/src/drivers/serial.c
+++ b/src/drivers/serial.c
@@ -58,7 +58,6 @@ void serial_write_dec(uint64_t value)
         serial_write_char('0');
         return;
     }
-    
     while (value > 0)
     {
         buf[i++] = (char)('0' + (value % 10));

--- a/src/drivers/serial.c
+++ b/src/drivers/serial.c
@@ -78,7 +78,7 @@ void serial_write_size(uint64_t size)
     const uint64_t GB = 1024 * MB;
 
     uint64_t unit = 1;
-    const char* suffix = " B";
+    const char *suffix = " B";
 
     if (size >= GB)
     {

--- a/src/drivers/serial.c
+++ b/src/drivers/serial.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <cpu.h>
 #include <serial.h>
 
@@ -45,4 +46,73 @@ void serial_write_hex64(uint64_t value)
             serial_write_char((char)('A' + nibble - 10));
         }
     }
+}
+
+void serial_write_dec(uint64_t value)
+{
+    char buf[21];   // uint64_t max = 18,446,744,073,709,551,615 -> 20자리 + 여유분
+    size_t i = 0;
+
+    if (value == 0)
+    {
+        serial_write_char('0');
+        return;
+    }
+    
+    while (value > 0)
+    {
+        buf[i++] = (char)('0' + (value % 10));
+        value /= 10;
+    }
+
+    while (i > 0)
+    {
+        serial_write_char(buf[--i]);
+    }
+}
+
+void serial_write_size(uint64_t size)
+{
+    const uint64_t KB = 1024;
+    const uint64_t MB = 1024 * KB;
+    const uint64_t GB = 1024 * MB;
+
+    uint64_t unit = 1;
+    const char* suffix = " B";
+
+    if (size >= GB)
+    {
+        unit = GB;
+        suffix = " GB";
+    }
+    else if (size >= MB)
+    {
+        unit = MB;
+        suffix = " MB";
+    }
+    else if (size >= KB)
+    {
+        unit = KB;
+        suffix = " KB";
+    }
+
+    uint64_t whole = size / unit;
+    uint64_t remainder = size % unit; // overflow 방지를 위해 소수점을 위한 나머지 계산
+    uint64_t frac = (remainder * 100) / unit;
+
+    serial_write_dec(whole);
+
+    if (unit != 1) // B는 소수점 없음
+    {
+        serial_write_char('.');
+
+        if (frac < 10)
+        {
+            serial_write_char('0');
+        }
+
+        serial_write_dec(frac);
+    }
+
+    serial_write(suffix);
 }

--- a/src/include/serial.h
+++ b/src/include/serial.h
@@ -8,5 +8,7 @@ void serial_init(void);
 void serial_write_char(char c);
 void serial_write(const char *s);
 void serial_write_hex64(uint64_t value);
+void serial_write_dec(uint64_t value);
+void serial_write_size(uint64_t size);
 
 #endif

--- a/src/kernel/multiboot.c
+++ b/src/kernel/multiboot.c
@@ -18,45 +18,34 @@ static uint64_t align_down(uint64_t addr) {
 }
 
 // ###################################################################################################
-// Debug output (simple decimal printer for early stage)
-static void serial_write_u32(uint32_t value) {
-    char buf[11];
-    uint32_t i = 0;
-
-    if (value == 0) {
-        serial_write_char('0');
-        return;
-    }
-
-    // Convert integer to string (reverse order)
-    while (value > 0) {
-        buf[i++] = (char)('0' + (value % 10));
-        value /= 10;
-    }
-
-    // Print in correct order
-    while (i > 0) {
-        serial_write_char(buf[--i]);
-    }
-}
-
 // Dump current usable memory regions (for debugging)
 static void dump_usable_regions(const char *label) {
+    uint64_t total = 0;
+
     serial_write("[MMAP] ");
     serial_write(label);
     serial_write(", count=");
-    serial_write_u32(usable_region_count);
+    serial_write_dec(usable_region_count);
     serial_write("\n");
 
     for (uint32_t i = 0; i < usable_region_count; i++) {
+        uint64_t size = usable_regions[i].end - usable_regions[i].start;
         serial_write("[MMAP] region[");
-        serial_write_u32(i);
+        serial_write_dec(i);
         serial_write("] start=");
         serial_write_hex64(usable_regions[i].start);
         serial_write(" end=");
         serial_write_hex64(usable_regions[i].end);
+        serial_write(" size=");
+        serial_write_size(size);
         serial_write("\n");
+
+        total += size;
     }
+
+    serial_write("[MMAP] total usable = ");
+    serial_write_size(total);
+    serial_write("\n");
 }
 // ###################################################################################################
 


### PR DESCRIPTION
This pull request enhances the serial driver by adding new utility functions for decimal and human-readable size output, and updates memory region debugging output to use these improvements. The main changes are grouped below:

**Serial driver enhancements:**

* Added `serial_write_dec` for printing 64-bit unsigned integers in decimal format, and `serial_write_size` for printing sizes in a human-readable format (e.g., KB, MB, GB) in `src/drivers/serial.c` and declared them in `src/include/serial.h`. [[1]](diffhunk://#diff-e2937c3b56e9dd59a635c821e72ea1806d47cb303d46aaa578ee44aa452509d8R50-R118) [[2]](diffhunk://#diff-3009109b9a2b5388d53d640a8d90c36d883161adde051a86d3635bd56e2908d6R11-R12)
* Included the `<stddef.h>` header in `src/drivers/serial.c` to support the new functions.

**Debug output improvements:**

* Removed the local `serial_write_u32` decimal printer from `src/kernel/multiboot.c` and updated debug output to use the new `serial_write_dec` and `serial_write_size` functions. This results in clearer, more informative memory region dumps, including human-readable region sizes and total usable memory.

**Example output**

<img width="1965" height="523" alt="Screenshot from 2026-03-27 00-46-40" src="https://github.com/user-attachments/assets/69c29acb-0795-4ccb-b17b-036326531bc6" />
