### PR TITLE
bugfix: pmm_init 분할

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 # ---------------------------------
-# toolchain
+# toolchain (fixed)
 # ---------------------------------
 
-CC := x86_64-elf-gcc
-AS := x86_64-elf-as
+PREFIX := /opt/cross
+CC := $(PREFIX)/bin/x86_64-elf-gcc
+AS := $(PREFIX)/bin/x86_64-elf-as
 
 SRC := src
 BUILD := build
+ISODIR := isodir
 
-CFLAGS := -ffreestanding -m64 -fno-stack-protector -fno-pie -mno-red-zone -O2 -Wall -Wextra -I $(SRC)/include
+CFLAGS := -ffreestanding -m64 -mcmodel=kernel -fno-stack-protector -fno-pie -mno-red-zone -O2 -Wall -Wextra -g -I $(SRC)/include
 LDFLAGS := -ffreestanding -nostdlib -no-pie -Wl,--build-id=none -Wl,-z,noexecstack
-
 
 # ---------------------------------
 # source discovery
@@ -19,7 +20,6 @@ LDFLAGS := -ffreestanding -nostdlib -no-pie -Wl,--build-id=none -Wl,-z,noexecsta
 C_SOURCES := $(shell find $(SRC) -name "*.c")
 ASM_SOURCES_S := $(shell find $(SRC) -name "*.S")
 ASM_SOURCES_s := $(shell find $(SRC) -name "*.s")
-
 
 # ---------------------------------
 # object files
@@ -31,15 +31,13 @@ ASM_OBJS += $(patsubst $(SRC)/%.s,$(BUILD)/%.o,$(ASM_SOURCES_s))
 
 OBJS := $(C_OBJS) $(ASM_OBJS)
 
-
 # ---------------------------------
 # targets
 # ---------------------------------
 
-.PHONY: all clean iso run
+.PHONY: all clean iso run run-debug
 
 all: $(BUILD)/kernel.elf
-
 
 # ---------------------------------
 # link kernel
@@ -48,58 +46,74 @@ all: $(BUILD)/kernel.elf
 $(BUILD)/kernel.elf: $(OBJS)
 	$(CC) -T linker.ld -o $@ $(LDFLAGS) $(OBJS) -lgcc
 
-
 # ---------------------------------
-# compile C
+# compile rules
 # ---------------------------------
 
 $(BUILD)/%.o: $(SRC)/%.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-
-# ---------------------------------
-# compile preprocessed asm (.S)
-# ---------------------------------
-
 $(BUILD)/%.o: $(SRC)/%.S
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
-
-
-# ---------------------------------
-# compile raw asm (.s)
-# ---------------------------------
 
 $(BUILD)/%.o: $(SRC)/%.s
 	@mkdir -p $(dir $@)
 	$(AS) $< -o $@
 
-
 # ---------------------------------
-# ISO build
+# ISO build (FINAL, stable)
 # ---------------------------------
 
 $(BUILD)/myos.iso: $(BUILD)/kernel.elf
-	cp $(BUILD)/kernel.elf isodir/boot/kernel.elf
-	grub-mkrescue -o $(BUILD)/myos.iso isodir
+	@echo "[*] Preparing ISO directory"
+	mkdir -p $(ISODIR)/boot/grub
+	rm -f $(ISODIR)/boot/kernel.elf
+
+	cp $(BUILD)/kernel.elf $(ISODIR)/boot/kernel.elf
+	@if [ ! -f $(ISODIR)/boot/grub/grub.cfg ]; then \
+		cp grub.cfg $(ISODIR)/boot/grub/grub.cfg; \
+	fi
+
+	@echo "[*] Building hybrid ISO (BIOS + UEFI)"
+	grub-mkrescue \
+	  -o $(BUILD)/myos.iso \
+	  $(ISODIR)
 
 iso: $(BUILD)/myos.iso
 
-
 # ---------------------------------
-# run
+# run (UEFI - OVMF)
 # ---------------------------------
 
-run: $(BUILD)/myos.iso
+run:
+	$(MAKE) clean
+	$(MAKE) $(BUILD)/myos.iso
 	qemu-system-x86_64 \
-	  -m 8G \
+		-m 2G \
+		-cdrom $(BUILD)/myos.iso \
+		-bios /usr/share/OVMF/OVMF_CODE.fd \
+		-vga std \
+		-serial stdio \
+		-no-reboot \
+		-no-shutdown
+
+run-debug: 
+	$(MAKE) clean
+	$(MAKE) $(BUILD)/myos.iso
+	qemu-system-x86_64 \
+	  -m 2G \
 	  -cdrom $(BUILD)/myos.iso \
 	  -bios /usr/share/OVMF/OVMF_CODE.fd \
+	  -display none \
+	  -vga std \
+	  -monitor none \
 	  -serial stdio \
+	  -no-reboot \
 	  -no-shutdown \
-	  -no-reboot
-
+	  -d int,cpu_reset \
+	  -D $(BUILD)/qemu-debug.log
 
 # ---------------------------------
 # clean
@@ -107,3 +121,4 @@ run: $(BUILD)/myos.iso
 
 clean:
 	rm -rf $(BUILD)
+	rm -f $(ISODIR)/boot/kernel.elf

--- a/isodir/boot/grub/grub.cfg
+++ b/isodir/boot/grub/grub.cfg
@@ -1,12 +1,11 @@
-set timeout=0
+set timeout=5
 set default=0
 
-set gfxpayload=text
-set gfxterm_font=unicode
-insmod all_video
-terminal_output console
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal_input serial
+terminal_output serial
 
-menuentry "myos" {
+menuentry "mini-dOs" {
     multiboot2 /boot/kernel.elf
     boot
 }

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -1,0 +1,1 @@
+#define PMM_DEBUG

--- a/src/include/mm/pmm.h
+++ b/src/include/mm/pmm.h
@@ -2,11 +2,10 @@
 #define PMM_H
 
 #include <stdint.h>
-#include <stddef.h>
-#include <multiboot.h>
 
-#define PAGE_SIZE	4096	// 4KB
-#define MAX_ORDER	10	// 4KB * 2^10 = 4MB
+#define	PAGE_SIZE	4096	// 4KB
+#define	MAX_ORDER	10	// 4KB * 2^10 = 4MB
+#define	PMM_STEP_LIMIT	(1UL << 30)
 
 // free block을 연결 리스트로 관리하기 위한 노드
 typedef struct block {
@@ -21,6 +20,7 @@ typedef struct buddy_pmm {
 
 void *pmm_alloc(uint32_t order);
 void pmm_free(void *addr, uint32_t order);
-void pmm_init();
+void pmm_init_step1();
+void pmm_init_step2();
 
 #endif

--- a/src/kernel/kmain.c
+++ b/src/kernel/kmain.c
@@ -24,13 +24,15 @@ void kmain(uint32_t multiboot_magic, uint32_t multiboot_info) {
 
     init_early_alloc();
     multiboot_parse((void *)(uint64_t)multiboot_info);
-    pmm_init();
+    pmm_init_step1();
 
     serial_write("Memory parsing done\r\n");
 
     paging_init();
 
     serial_write("Paging initialized\r\n");
+
+    pmm_init_step2();
 
     init_interrupt_subsystem();
 

--- a/src/mm/pmm.c
+++ b/src/mm/pmm.c
@@ -1,8 +1,22 @@
+#include <config.h>
 #include <mm/pmm.h>
-#include <multiboot.h>
+#include <multiboot.h>	// usable_region 사용을 위해
 #include <serial.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef PMM_DEBUG
+	#define	PMM_DEBUG_MSG(s)	serial_write(s)
+	#define	PMM_DEBUG_DEC(n)	serial_write_dec(n)
+	#define	PMM_DEBUG_NEWLINE()	serial_write("\r\n")
+#else
+	#define	PMM_DEBUG_MSG(s)	((void)0)
+	#define	PMM_DEBUG_DEC(n)	((void)0)
+	#define	PMM_DEBUG_NEWLINE()	((void)0)
+#endif
 
 extern uint64_t _kernel_end;
+uint32_t last_region;
 
 static buddy_pmm_t pmm;
 
@@ -81,32 +95,107 @@ void pmm_free(void* addr, uint32_t order) {
 	pmm.free_pages += (1 << order);
 }
 
-void pmm_init() {
-	serial_write("[pmm_init] start\r\n");
+void pmm_init_step1() {
+	PMM_DEBUG_NEWLINE();
+	PMM_DEBUG_MSG("[pmm_init_step1] start");
+	PMM_DEBUG_NEWLINE();
+	PMM_DEBUG_MSG("Usable Region Num: ");
+	PMM_DEBUG_DEC(usable_region_count);
+	PMM_DEBUG_NEWLINE();
 
 	uint64_t page_num = 0;
 
-	serial_write("usable_region_count: ");
-	serial_write_dec(usable_region_count);
-	serial_write("\r\n\n");
+	for (uint32_t i = 0; i < usable_region_count; i++) {
+		PMM_DEBUG_MSG("Region #");
+		PMM_DEBUG_DEC(i);
+		PMM_DEBUG_NEWLINE();
 
-	for (uint16_t i = 0; i < usable_region_count; i++) {
 		page_num = (usable_regions[i].end - usable_regions[i].start) >> 12;
 		
 		uint64_t pivot_addr = usable_regions[i].start;
 
 		for (uint32_t j = 0; j < page_num; j++) {
+			if (pivot_addr < PMM_STEP_LIMIT) {
+				pmm_free((void*)pivot_addr, 0);
+				pmm.total_pages++;
+
+				pivot_addr += PAGE_SIZE;
+			} else {
+				last_region = i;
+				i = usable_region_count;
+				break;
+			}
+		}
+
+		PMM_DEBUG_MSG("Sum of Total Page: ");
+		PMM_DEBUG_DEC(pmm.total_pages);
+		PMM_DEBUG_NEWLINE();
+	}
+
+	PMM_DEBUG_MSG("[pmm_init_step1] done");
+	PMM_DEBUG_NEWLINE();
+	PMM_DEBUG_NEWLINE();
+}
+
+void pmm_init_step2() {
+	PMM_DEBUG_NEWLINE();
+	PMM_DEBUG_MSG("[pmm_init_step2] start");
+	PMM_DEBUG_NEWLINE();
+	PMM_DEBUG_MSG("Region #");
+	PMM_DEBUG_DEC(last_region);
+	PMM_DEBUG_NEWLINE();
+
+	serial_write_hex64(usable_regions[last_region].start);
+	PMM_DEBUG_NEWLINE();
+	serial_write_hex64(usable_regions[last_region].end);
+	PMM_DEBUG_NEWLINE();
+	uint64_t page_num = (usable_regions[last_region].end - usable_regions[last_region].start) >> 12;
+	PMM_DEBUG_MSG(">");
+	PMM_DEBUG_NEWLINE();
+	PMM_DEBUG_DEC(page_num);
+	PMM_DEBUG_NEWLINE();
+		
+	uint64_t last_pivot_addr = usable_regions[last_region].start;
+	serial_write_hex64(last_pivot_addr);
+	PMM_DEBUG_NEWLINE();
+
+	for (uint32_t i = 0; i < page_num; i++) {
+		if (last_pivot_addr <= PMM_STEP_LIMIT) {
+			last_pivot_addr += PAGE_SIZE;
+			PMM_DEBUG_MSG(".");
+		} else {
+			pmm_free((void*)last_pivot_addr, 0);
 			pmm.total_pages++;
+
+			last_pivot_addr += PAGE_SIZE;
+		}
+	}
+
+	PMM_DEBUG_MSG("Sum of Total Page: ");
+	PMM_DEBUG_DEC(pmm.total_pages);
+	PMM_DEBUG_NEWLINE();
+
+	for (uint32_t i = last_region + 1; i < usable_region_count; i++) {
+		PMM_DEBUG_MSG("Region #");
+		PMM_DEBUG_DEC(i);
+		PMM_DEBUG_NEWLINE();
+
+		page_num = (usable_regions[i].end - usable_regions[i].start) >> 12;
+		
+		uint64_t pivot_addr = usable_regions[i].start;
+
+		for (uint32_t j = 0; j < page_num; j++) {
 			pmm_free((void*)pivot_addr, 0);
+			pmm.total_pages++;
 
 			pivot_addr += PAGE_SIZE;
 		}
-		serial_write("usable_regions[");
-		serial_write_dec(i);
-		serial_write("]: ");
-		serial_write_dec(pmm.total_pages);
-		serial_write("\r\n");
+
+		PMM_DEBUG_MSG("Sum of Total Page: ");
+		PMM_DEBUG_DEC(pmm.total_pages);
+		PMM_DEBUG_NEWLINE();
 	}
 
-	serial_write("[pmm_init] done\r\n");
+	PMM_DEBUG_MSG("[pmm_init_step2] done");
+	PMM_DEBUG_NEWLINE();
 }


### PR DESCRIPTION
- 일단 아직도 페이징이 안 되고 있다. 페이징이라는 말이 맞는지도 모르겠다.
- pmm_init()을 pmm_init_step1(), pmm_init_step2()로 나눠서 GRUB에서 만들었던 페이지 테이블의 영역인 1GB까지는 pmm_init_step1()이 담당하고 그 이후는 pmm_init_step2()가 담당하게 코드를 짰다.
- 하.지.만! 전혀 안 되고 있다. paging_init()을 보겸이가 짰는데 보겸이는 코드를 보고 자기 CR3에 문제가 있다는 것 같다. 난 paging.c를 안 짜서 뭔 말인지 모르겠다.
- 어쨌든 고쳐준다니까 일단 push한다.