### PR TITLE
feat: slab allocator

### DIFF
--- a/src/include/mm/slab.h
+++ b/src/include/mm/slab.h
@@ -24,7 +24,7 @@ typedef struct kmem_cache {
 	slab_t* empty;		// 얘만 Linked List 아님
 } kmem_cache_t;
 
-kmem_cache_t kmem_cache_list[KMEM_CACHE_COUNT];
+extern kmem_cache_t kmem_cache_list[KMEM_CACHE_COUNT];
 
 void* object_alloc(kmem_cache_t* kmem_cache);
 void object_free(kmem_cache_t* kmem_cache, void* object);

--- a/src/include/mm/slab.h
+++ b/src/include/mm/slab.h
@@ -1,0 +1,36 @@
+#ifndef SLAB_H
+#define SLAB_H
+
+#include <mm/paging.h>
+#include <mm/vmm.h>
+
+#define	KMEM_CACHE_COUNT 9	// 8B ~ 2KB (9개)
+
+typedef struct slab slab_t;
+typedef struct kmem_cache kmem_cache_t;
+
+typedef struct slab {
+	kmem_cache_t* kmem_cache;
+	slab_t* next;	// kmem_cache에서 Linked List로 관리하기 위해 필요
+	uint32_t free_count;
+	void* free_list;	// slab 내부의 object를 Linked List로 관리하기 위해 필요
+} slab_t;
+
+typedef struct kmem_cache {
+	uint64_t obj_size;	// 8B ~ 2KB (9개)
+	uint64_t obj_capacity;	// cache가 담당하는 obj의 크기들로 쪼개질 수 있는 obj의 개수
+	slab_t* full;
+	slab_t* partial;
+	slab_t* empty;		// 얘만 Linked List 아님
+} kmem_cache_t;
+
+kmem_cache_t kmem_cache_list[KMEM_CACHE_COUNT];
+
+void* object_alloc(kmem_cache_t* kmem_cache);
+void object_free(kmem_cache_t* kmem_cache, void* object);
+void* kmalloc(uint64_t size);
+void kfree(void* object);
+void slab_init(kmem_cache_t* kmem_cache, slab_t* slab);
+void kmem_cache_init();
+
+#endif

--- a/src/mm/slab.c
+++ b/src/mm/slab.c
@@ -1,0 +1,172 @@
+#include <kernel_base.h>	// phys_to_virt
+#include <kernel_info.h>
+#include <mm/paging.h>
+#include <mm/pmm.h>
+#include <mm/vmm.h>
+
+#define KMEM_CACHE_COUNT 9
+
+void* object_alloc(kmem_cache_t* kmem_cache) {
+	slab_t* slab;
+
+	if (kmem_cache->partial == NULL) {
+		if (kmem_cache->empty == NULL) {	// 빈 slab이 하나도 없을 경우
+			slab = (slab_t*)phys_to_virt((uintptr_t)pmm_alloc(0));	// 4KB 페이지 할당
+
+			slab_init(kmem_cache, slab);
+		} else {	// empty slab이라도 있을 경우
+			slab = kmem_cache->empty;
+		}
+	} else {
+		slab = kmem_cache->partial;
+	}
+
+	/* 실제 object 할당 */
+	void* object = slab->free_list;
+	slab->free_list = (void*)*((uintptr_t*)slab->free_list);
+	slab->free_count--;
+
+	// object가 2KB인 경우에는 object_capacity가 1이기 때문에 발생 가능
+	// empty -> full이 된 경우
+	if (kmem_cache->partial == NULL && slab->free_count == 0) {
+		slab->next = kmem_cache->full;
+		kmem_cache->full = slab;
+		kmem_cache->empty = NULL;
+	} // partial -> full이 된 경우
+	else if (slab->free_count == 0) {
+		slab_t* prev = kmem_cache->partial;
+
+		// slab을 partial list에서 제거
+		if (prev != slab) {
+			while (prev->next != slab) prev = prev->next;
+
+			prev->next = prev->next->next;
+		} else {
+			kmem_cache->partial = prev->next;
+		}
+		
+		// full에 추가
+		slab->next = kmem_cache->full;
+		kmem_cache->full = slab;
+	} // empty -> partial이 된 경우
+	else if (slab->free_count == kmem_cache->obj_capacity - 1) {
+		// partial에 추가
+		slab->next = kmem_cache->partial;
+		kmem_cache->partial = slab;
+		kmem_cache->empty = NULL;
+	}
+
+	return object;
+}
+
+void object_free(kmem_cache_t* kmem_cache, void* object) {
+	// object의 slab 주소
+	slab_t* slab = (slab_t*)((uintptr_t)object & ~(0xFFF));	// 포인터를 정수 타입으로 변환 후 비트 연산 (포인터는 비트 연산이 안 됨)
+
+	/* 실제 object 반환 */
+	*((uintptr_t*)object) = (uintptr_t)slab->free_list;
+	slab->free_list = (void*)object;
+	slab->free_count++;
+
+	// object가 2KB인 경우에는 object_capacity가 1이기 때문에 발생 가능
+	// full -> empty가 된 경우
+	if (kmem_cache->obj_capacity == 1) {
+		slab_t* prev = kmem_cache->full;
+
+		// slab을 full list에서 제거
+		if (prev != slab) {
+			while (prev->next != slab) prev = prev->next;
+
+			prev->next = prev->next->next;
+		} else {
+			kmem_cache->full = prev->next;
+		}
+
+		// empty가 없을 경우
+		if (kmem_cache->empty == NULL) kmem_cache->empty = slab;
+		// empty가 있을 경우
+		else pmm_free((void*)slab, 0);	// 4KB 페이지 반환
+	} // partial -> empry가 된 경우
+	else if (slab->free_count == kmem_cache->obj_capacity) {
+		slab_t* prev = kmem_cache->partial;
+
+		// slab을 partial list에서 제거
+		if (prev != slab) {
+			while (prev->next != slab) prev = prev->next;
+
+			prev->next = prev->next->next;
+		} else {
+			kmem_cache->partial = prev->next;
+		}
+
+		// empty가 없을 경우
+		if (kmem_cache->empty == NULL) kmem_cache->empty = slab;
+		// empty가 있을 경우
+		else pmm_free((void*)slab, 0);	// 4KB 페이지 반환
+	} // full -> partial이 된 경우
+	else if (slab->free_count == 1) {
+		slab_t* prev = kmem_cache->full;
+
+		// slab을 full list에서 제거
+		if (prev != slab) {
+			while (prev->next != slab) prev = prev->next;
+
+			prev->next = prev->next->next;
+		} else {
+			kmem_cache->full = prev->next;
+		}
+
+		// partial에 추가
+		slab->next = kmem_cache->partial;
+		kmem_cache->partial = slab;
+	}
+}
+
+void* kmalloc(uint64_t size) {
+	void* object = NULL;
+
+	int i = 0;
+	for (i = 0; i < KMEM_CACHE_COUNT; i++) {
+		if (size <= (8 << i)) break;
+	}
+
+	// 8B ~ 2KB 담당
+	if (i < KMEM_CACHE_COUNT) {
+		object = object_alloc(&kmem_cache_list[i]);
+	} // 2KB 이상은 직접 pmm_alloc으로 할당
+	else {
+	}
+
+	return object;
+}
+
+void kfree(void* object) {
+
+}
+
+void slab_init(kmem_cache_t* kmem_cache, slab_t* slab) {
+	slab->kmem_cache = kmem_cache;
+	slab->next = NULL;
+	slab->free_count = slab->kmem_cache->obj_capacity;
+	slab->free_list = (uint8_t*)slab + sizeof(slab_t);
+
+	void* prev = slab->free_list;
+
+	for (int i = 0; i < slab->kmem_cache->obj_capacity - 1; i++) {
+		*((uintptr_t*)prev) = (uintptr_t)((uint8_t*)prev + slab->kmem_cache->obj_size);
+		prev = (void*)*((uintptr_t*)prev);
+	}
+	*((uintptr_t*)prev) = 0;
+}
+
+void kmem_cache_init() {
+	uint64_t sizes[KMEM_CACHE_COUNT] = {8, 16, 32, 64, 128, 256, 512, 1024, 2048};	// 9개
+
+	for (int i = 0; i < KMEM_CACHE_COUNT; i++) {
+		kmem_cache_list[i].obj_size = sizes[i];
+		kmem_cache_list[i].obj_capacity = (PAGE_SIZE - sizeof(slab_t)) / sizes[i];
+		kmem_cache_list[i].full = NULL;
+		kmem_cache_list[i].partial = NULL;
+		kmem_cache_list[i].empty = NULL;
+	}
+}

--- a/src/mm/slab.c
+++ b/src/mm/slab.c
@@ -2,9 +2,10 @@
 #include <kernel_info.h>
 #include <mm/paging.h>
 #include <mm/pmm.h>
+#include <mm/slab.h>
 #include <mm/vmm.h>
 
-#define KMEM_CACHE_COUNT 9
+kmem_cache_t kmem_cache_list[KMEM_CACHE_COUNT];	// KMEM_CACHE_COUNT는 9 (mm/slab.h)
 
 void* object_alloc(kmem_cache_t* kmem_cache) {
 	slab_t* slab;
@@ -85,8 +86,8 @@ void object_free(kmem_cache_t* kmem_cache, void* object) {
 		// empty가 없을 경우
 		if (kmem_cache->empty == NULL) kmem_cache->empty = slab;
 		// empty가 있을 경우
-		else pmm_free((void*)slab, 0);	// 4KB 페이지 반환
-	} // partial -> empry가 된 경우
+		else pmm_free((void*)virt_to_phys((void*)slab), 0);	// 4KB 페이지 반환
+	} // partial -> empty가 된 경우
 	else if (slab->free_count == kmem_cache->obj_capacity) {
 		slab_t* prev = kmem_cache->partial;
 
@@ -102,7 +103,7 @@ void object_free(kmem_cache_t* kmem_cache, void* object) {
 		// empty가 없을 경우
 		if (kmem_cache->empty == NULL) kmem_cache->empty = slab;
 		// empty가 있을 경우
-		else pmm_free((void*)slab, 0);	// 4KB 페이지 반환
+		else pmm_free((void*)virt_to_phys((void*)slab), 0);	// 4KB 페이지 반환
 	} // full -> partial이 된 경우
 	else if (slab->free_count == 1) {
 		slab_t* prev = kmem_cache->full;
@@ -145,10 +146,17 @@ void kfree(void* object) {
 }
 
 void slab_init(kmem_cache_t* kmem_cache, slab_t* slab) {
+	uint64_t obj_size = kmem_cache->obj_size;
+	uint64_t obj_capacity = kmem_cache->obj_capacity;
+	uint64_t header_size = (uint64_t)sizeof(slab_t);
+
 	slab->kmem_cache = kmem_cache;
 	slab->next = NULL;
-	slab->free_count = slab->kmem_cache->obj_capacity;
-	slab->free_list = (uint8_t*)slab + sizeof(slab_t);
+	slab->free_count = obj_capacity;
+	if (header_size % obj_size == 0)	// header가 obj 크기와 딱 맞을 경우
+		slab->free_list = (uint8_t*)slab + header_size;
+	else	// header가 obj 크기와 다를 경우; (header_size / obj_size + 1)을 통해 header가 obj보다 작을 경우도 산정
+		slab->free_list = (uint8_t*)slab + obj_size * (header_size / obj_size + 1);
 
 	void* prev = slab->free_list;
 
@@ -164,7 +172,11 @@ void kmem_cache_init() {
 
 	for (int i = 0; i < KMEM_CACHE_COUNT; i++) {
 		kmem_cache_list[i].obj_size = sizes[i];
-		kmem_cache_list[i].obj_capacity = (PAGE_SIZE - sizeof(slab_t)) / sizes[i];
+		// 패딩을 위한 로직
+		if (sizeof(slab_t) % sizes[i] == 0)
+			kmem_cache_list[i].obj_capacity = (PAGE_SIZE - sizeof(slab_t)) / sizes[i];
+		else
+			kmem_cache_list[i].obj_capacity = (PAGE_SIZE - (sizes[i] * (sizeof(slab_t) / sizes[i] + 1))) / sizes[i];
 		kmem_cache_list[i].full = NULL;
 		kmem_cache_list[i].partial = NULL;
 		kmem_cache_list[i].empty = NULL;


### PR DESCRIPTION
[완성]
- slab.h에 구조체들 정의
- slab.c에 함수들 정의
- kmain.c에서 초기화 담당: kmem_cache_init()
- slab 생성: slab_init()
- object 할당/해제: object_alloc()/object_free()

[미완성]
- object 할당 API: kmalloc()/kfree()
- page_t 구현이 돼야 진행 가능

[요약]
- 8B~2KB object는 할당 가능
- 하지만 2KB 초과 할당은 불가능
- 메모리 해제도 불가능