### PR TITLE
feat: stdio, errno, sys/mkdir

### DIFF
--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -19,4 +19,48 @@ extern FILE *stderr;
 
 typedef long fpos_t;
 
+extern int    printf(const char *fmt, ...);
+extern int    fprintf(FILE *stream, const char *fmt, ...);
+extern int    sprintf(char *str, const char *fmt, ...);
+extern int    snprintf(char *str, size_t size, const char *fmt, ...);
+extern int    vprintf(const char *fmt, va_list ap);
+extern int    vfprintf(FILE *stream, const char *fmt, va_list ap);
+extern int    vsprintf(char *str, const char *fmt, va_list ap);
+extern int    vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
+extern int    sscanf(const char *str, const char *fmt, ...);
+extern int    vsscanf(const char *str, const char *fmt, va_list ap);
+
+extern int    puts(const char *s);
+extern int    putchar(int c);
+extern int    fputs(const char *s, FILE *stream);
+extern int    fputc(int c, FILE *stream);
+extern int    putc(int c, FILE *stream);
+
+extern int    fgetc(FILE *stream);
+extern int    getc(FILE *stream);
+extern char  *fgets(char *s, int size, FILE *stream);
+
+extern FILE  *fopen(const char *path, const char *mode);
+extern int    fclose(FILE *stream);
+extern size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+extern size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+extern int    fseek(FILE *stream, long offset, int whence);
+extern long   ftell(FILE *stream);
+extern void   rewind(FILE *stream);
+extern int    fflush(FILE *stream);
+extern int    feof(FILE *stream);
+extern int    ferror(FILE *stream);
+extern void   clearerr(FILE *stream);
+extern int    fileno(FILE *stream);
+extern void   setbuf(FILE *stream, char *buf);
+extern int    setvbuf(FILE *stream, char *buf, int mode, size_t size);
+
+extern int    remove(const char *path);
+extern int    rename(const char *oldpath, const char *newpath);
+
+extern void   perror(const char *s);
+
+extern void   libc_stdio_init(void);
+extern void   libc_register_module(const char *name, const void *base, size_t size);
+
 #endif

--- a/libc/include/sys/stat.h
+++ b/libc/include/sys/stat.h
@@ -30,4 +30,7 @@ struct stat {
 #define S_IWOTH 0002
 #define S_IXOTH 0001
 
+extern int mkdir(const char *path, mode_t mode);
+extern int stat(const char *path, struct stat *buf);
+
 #endif

--- a/libc/src/errno.c
+++ b/libc/src/errno.c
@@ -1,0 +1,3 @@
+#include <errno.h>
+
+int errno = 0;

--- a/libc/src/stdio/clearerr.c
+++ b/libc/src/stdio/clearerr.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+void clearerr(FILE *stream) {
+    if (!stream) return;
+    stream->flags &= ~(FILE_FLAG_EOF | FILE_FLAG_ERR);
+}

--- a/libc/src/stdio/fclose.c
+++ b/libc/src/stdio/fclose.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "file_internal.h"
+
+int fclose(FILE *stream) {
+    if (!stream) return EOF;
+    if (stream == stdin || stream == stdout || stream == stderr) return 0;
+    free(stream);
+    return 0;
+}

--- a/libc/src/stdio/feof.c
+++ b/libc/src/stdio/feof.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int feof(FILE *stream) {
+    if (!stream) return 0;
+    return (stream->flags & FILE_FLAG_EOF) != 0;
+}

--- a/libc/src/stdio/ferror.c
+++ b/libc/src/stdio/ferror.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int ferror(FILE *stream) {
+    if (!stream) return 0;
+    return (stream->flags & FILE_FLAG_ERR) != 0;
+}

--- a/libc/src/stdio/fflush.c
+++ b/libc/src/stdio/fflush.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int fflush(FILE *stream) {
+    (void)stream;
+    return 0;
+}

--- a/libc/src/stdio/fgetc.c
+++ b/libc/src/stdio/fgetc.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int fgetc(FILE *stream) {
+    if (!stream) return EOF;
+
+    if (stream->backend == FILE_BACKEND_MEMORY) {
+        if (stream->mem.pos >= stream->mem.size) {
+            stream->flags |= FILE_FLAG_EOF;
+            return EOF;
+        }
+        return stream->mem.base[stream->mem.pos++];
+    }
+
+    if (stream->backend == FILE_BACKEND_STREAM && stream->stream.read) {
+        char c;
+        int rc = stream->stream.read(stream->stream.ctx, &c, 1);
+        if (rc <= 0) {
+            if (rc == 0) stream->flags |= FILE_FLAG_EOF;
+            else         stream->flags |= FILE_FLAG_ERR;
+            return EOF;
+        }
+        return (unsigned char)c;
+    }
+
+    return EOF;
+}

--- a/libc/src/stdio/fgets.c
+++ b/libc/src/stdio/fgets.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+char *fgets(char *s, int size, FILE *stream) {
+    if (!s || size <= 0 || !stream) return NULL;
+    int i = 0;
+    while (i < size - 1) {
+        int c = fgetc(stream);
+        if (c == EOF) {
+            if (i == 0) return NULL;
+            break;
+        }
+        s[i++] = (char)c;
+        if (c == '\n') break;
+    }
+    s[i] = '\0';
+    return s;
+}

--- a/libc/src/stdio/file_internal.h
+++ b/libc/src/stdio/file_internal.h
@@ -1,0 +1,52 @@
+#ifndef _LIBC_STDIO_FILE_INTERNAL_H
+#define _LIBC_STDIO_FILE_INTERNAL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define FILE_FLAG_EOF    0x01
+#define FILE_FLAG_ERR    0x02
+#define FILE_FLAG_READ   0x04
+#define FILE_FLAG_WRITE  0x08
+
+typedef enum {
+    FILE_BACKEND_MEMORY = 1,
+    FILE_BACKEND_STREAM = 2,
+} file_backend_t;
+
+typedef int (*stream_write_fn)(void *ctx, const char *buf, size_t n);
+typedef int (*stream_read_fn)(void *ctx, char *buf, size_t n);
+
+struct _FILE {
+    file_backend_t backend;
+    unsigned int   flags;
+
+    union {
+        struct {
+            const uint8_t *base;
+            size_t         size;
+            size_t         pos;
+        } mem;
+
+        struct {
+            stream_write_fn write;
+            stream_read_fn  read;
+            void           *ctx;
+        } stream;
+    };
+};
+
+#define LIBC_MODULE_MAX 8
+
+typedef struct {
+    const char *name;
+    const void *base;
+    size_t      size;
+} libc_module_t;
+
+const libc_module_t *libc_lookup_module(const char *name);
+
+typedef void (*libc_emit_fn)(void *ctx, const char *s, size_t n);
+int _libc_vformat(libc_emit_fn emit, void *ctx, const char *fmt, __builtin_va_list ap);
+
+#endif

--- a/libc/src/stdio/fileno.c
+++ b/libc/src/stdio/fileno.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int fileno(FILE *stream) {
+    if (!stream) return -1;
+    if (stream == stdin)  return 0;
+    if (stream == stdout) return 1;
+    if (stream == stderr) return 2;
+    return 3;
+}

--- a/libc/src/stdio/fopen.c
+++ b/libc/src/stdio/fopen.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "file_internal.h"
+
+FILE *fopen(const char *path, const char *mode) {
+    if (!path || !mode) return NULL;
+
+    int want_write = 0;
+    for (const char *m = mode; *m; m++) {
+        if (*m == 'w' || *m == 'a' || *m == '+') { want_write = 1; break; }
+    }
+    if (want_write) return NULL;
+
+    const libc_module_t *mod = libc_lookup_module(path);
+    if (!mod) return NULL;
+
+    FILE *f = malloc(sizeof(*f));
+    if (!f) return NULL;
+    f->backend  = FILE_BACKEND_MEMORY;
+    f->flags    = FILE_FLAG_READ;
+    f->mem.base = mod->base;
+    f->mem.size = mod->size;
+    f->mem.pos  = 0;
+    return f;
+}

--- a/libc/src/stdio/fprintf.c
+++ b/libc/src/stdio/fprintf.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int fprintf(FILE *stream, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vfprintf(stream, fmt, ap);
+    va_end(ap);
+    return n;
+}

--- a/libc/src/stdio/fputc.c
+++ b/libc/src/stdio/fputc.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int fputc(int c, FILE *stream) {
+    if (!stream || stream->backend != FILE_BACKEND_STREAM || !stream->stream.write) return EOF;
+    char ch = (char)c;
+    int rc = stream->stream.write(stream->stream.ctx, &ch, 1);
+    if (rc < 0) {
+        stream->flags |= FILE_FLAG_ERR;
+        return EOF;
+    }
+    return (unsigned char)ch;
+}

--- a/libc/src/stdio/fputs.c
+++ b/libc/src/stdio/fputs.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int fputs(const char *s, FILE *stream) {
+    if (!stream || stream->backend != FILE_BACKEND_STREAM || !stream->stream.write) return EOF;
+    size_t n = 0;
+    while (s[n]) n++;
+    int rc = stream->stream.write(stream->stream.ctx, s, n);
+    if (rc < 0) {
+        stream->flags |= FILE_FLAG_ERR;
+        return EOF;
+    }
+    return rc;
+}

--- a/libc/src/stdio/fread.c
+++ b/libc/src/stdio/fread.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <string.h>
+#include "file_internal.h"
+
+size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
+    if (!ptr || !stream || size == 0 || nmemb == 0) return 0;
+
+    size_t total = size * nmemb;
+
+    if (stream->backend == FILE_BACKEND_MEMORY) {
+        size_t remain = stream->mem.size - stream->mem.pos;
+        size_t to_copy = total < remain ? total : remain;
+        memcpy(ptr, stream->mem.base + stream->mem.pos, to_copy);
+        stream->mem.pos += to_copy;
+        if (to_copy < total) stream->flags |= FILE_FLAG_EOF;
+        return to_copy / size;
+    }
+
+    if (stream->backend == FILE_BACKEND_STREAM && stream->stream.read) {
+        int rc = stream->stream.read(stream->stream.ctx, ptr, total);
+        if (rc < 0) { stream->flags |= FILE_FLAG_ERR; return 0; }
+        if ((size_t)rc < total) stream->flags |= FILE_FLAG_EOF;
+        return (size_t)rc / size;
+    }
+
+    return 0;
+}

--- a/libc/src/stdio/fseek.c
+++ b/libc/src/stdio/fseek.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+int fseek(FILE *stream, long offset, int whence) {
+    if (!stream || stream->backend != FILE_BACKEND_MEMORY) return -1;
+
+    long base;
+    switch (whence) {
+        case SEEK_SET: base = 0; break;
+        case SEEK_CUR: base = (long)stream->mem.pos; break;
+        case SEEK_END: base = (long)stream->mem.size; break;
+        default: return -1;
+    }
+
+    long new_pos = base + offset;
+    if (new_pos < 0 || (size_t)new_pos > stream->mem.size) return -1;
+    stream->mem.pos = (size_t)new_pos;
+    stream->flags &= ~FILE_FLAG_EOF;
+    return 0;
+}

--- a/libc/src/stdio/ftell.c
+++ b/libc/src/stdio/ftell.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+long ftell(FILE *stream) {
+    if (!stream || stream->backend != FILE_BACKEND_MEMORY) return -1;
+    return (long)stream->mem.pos;
+}

--- a/libc/src/stdio/fwrite.c
+++ b/libc/src/stdio/fwrite.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream) {
+    if (!ptr || !stream || size == 0 || nmemb == 0) return 0;
+
+    if (stream->backend == FILE_BACKEND_STREAM && stream->stream.write) {
+        size_t total = size * nmemb;
+        int rc = stream->stream.write(stream->stream.ctx, ptr, total);
+        if (rc < 0) { stream->flags |= FILE_FLAG_ERR; return 0; }
+        return (size_t)rc / size;
+    }
+
+    stream->flags |= FILE_FLAG_ERR;
+    return 0;
+}

--- a/libc/src/stdio/getc.c
+++ b/libc/src/stdio/getc.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int getc(FILE *stream) {
+    return fgetc(stream);
+}

--- a/libc/src/stdio/module_registry.c
+++ b/libc/src/stdio/module_registry.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include "file_internal.h"
+
+static libc_module_t modules[LIBC_MODULE_MAX];
+static size_t module_count = 0;
+
+void libc_register_module(const char *name, const void *base, size_t size) {
+    if (module_count >= LIBC_MODULE_MAX) return;
+    modules[module_count].name = name;
+    modules[module_count].base = base;
+    modules[module_count].size = size;
+    module_count++;
+}
+
+static const char *basename_p(const char *p) {
+    const char *b = p;
+    for (const char *q = p; *q; q++) {
+        if (*q == '/' || *q == '\\') b = q + 1;
+    }
+    return b;
+}
+
+const libc_module_t *libc_lookup_module(const char *name) {
+    if (!name) return NULL;
+    const char *qn = basename_p(name);
+    for (size_t i = 0; i < module_count; i++) {
+        if (!modules[i].name) continue;
+        if (strcasecmp(modules[i].name, name) == 0) return &modules[i];
+        const char *bn = basename_p(modules[i].name);
+        if (strcasecmp(bn, qn) == 0) return &modules[i];
+    }
+    return NULL;
+}

--- a/libc/src/stdio/perror.c
+++ b/libc/src/stdio/perror.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+void perror(const char *s) {
+    if (s && *s) {
+        fputs(s, stderr);
+        fputs(": ", stderr);
+    }
+    fputs("error\n", stderr);
+}

--- a/libc/src/stdio/printf.c
+++ b/libc/src/stdio/printf.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int printf(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vfprintf(stdout, fmt, ap);
+    va_end(ap);
+    return n;
+}

--- a/libc/src/stdio/putc.c
+++ b/libc/src/stdio/putc.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int putc(int c, FILE *stream) {
+    return fputc(c, stream);
+}

--- a/libc/src/stdio/putchar.c
+++ b/libc/src/stdio/putchar.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int putchar(int c) {
+    return fputc(c, stdout);
+}

--- a/libc/src/stdio/puts.c
+++ b/libc/src/stdio/puts.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int puts(const char *s) {
+    if (fputs(s, stdout) == EOF) return EOF;
+    if (fputc('\n', stdout) == EOF) return EOF;
+    return 1;
+}

--- a/libc/src/stdio/remove.c
+++ b/libc/src/stdio/remove.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <errno.h>
+
+int remove(const char *path) {
+    (void)path;
+    errno = EROFS;
+    return -1;
+}

--- a/libc/src/stdio/rename.c
+++ b/libc/src/stdio/rename.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <errno.h>
+
+int rename(const char *oldpath, const char *newpath) {
+    (void)oldpath;
+    (void)newpath;
+    errno = EROFS;
+    return -1;
+}

--- a/libc/src/stdio/rewind.c
+++ b/libc/src/stdio/rewind.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+void rewind(FILE *stream) {
+    if (!stream) return;
+    if (stream->backend == FILE_BACKEND_MEMORY) {
+        stream->mem.pos = 0;
+    }
+    stream->flags &= ~(FILE_FLAG_EOF | FILE_FLAG_ERR);
+}

--- a/libc/src/stdio/setbuf.c
+++ b/libc/src/stdio/setbuf.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+void setbuf(FILE *stream, char *buf) {
+    (void)stream;
+    (void)buf;
+}

--- a/libc/src/stdio/setvbuf.c
+++ b/libc/src/stdio/setvbuf.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int setvbuf(FILE *stream, char *buf, int mode, size_t size) {
+    (void)stream;
+    (void)buf;
+    (void)mode;
+    (void)size;
+    return 0;
+}

--- a/libc/src/stdio/snprintf.c
+++ b/libc/src/stdio/snprintf.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int snprintf(char *str, size_t size, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(str, size, fmt, ap);
+    va_end(ap);
+    return n;
+}

--- a/libc/src/stdio/sprintf.c
+++ b/libc/src/stdio/sprintf.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int sprintf(char *str, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsprintf(str, fmt, ap);
+    va_end(ap);
+    return n;
+}

--- a/libc/src/stdio/sscanf.c
+++ b/libc/src/stdio/sscanf.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int sscanf(const char *str, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsscanf(str, fmt, ap);
+    va_end(ap);
+    return n;
+}

--- a/libc/src/stdio/stdio_init.c
+++ b/libc/src/stdio/stdio_init.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <drivers/serial.h>
+#include "file_internal.h"
+
+static int serial_write_cb(void *ctx, const char *s, size_t n) {
+    (void)ctx;
+    for (size_t i = 0; i < n; i++) serial_write_char(s[i]);
+    return (int)n;
+}
+
+static struct _FILE _stdin_obj = {
+    .backend = FILE_BACKEND_STREAM,
+    .flags   = FILE_FLAG_READ,
+    .stream  = { NULL, NULL, NULL },
+};
+
+static struct _FILE _stdout_obj = {
+    .backend = FILE_BACKEND_STREAM,
+    .flags   = FILE_FLAG_WRITE,
+    .stream  = { serial_write_cb, NULL, NULL },
+};
+
+static struct _FILE _stderr_obj = {
+    .backend = FILE_BACKEND_STREAM,
+    .flags   = FILE_FLAG_WRITE,
+    .stream  = { serial_write_cb, NULL, NULL },
+};
+
+FILE *stdin  = &_stdin_obj;
+FILE *stdout = &_stdout_obj;
+FILE *stderr = &_stderr_obj;
+
+void libc_stdio_init(void) {
+}

--- a/libc/src/stdio/vformat.c
+++ b/libc/src/stdio/vformat.c
@@ -1,0 +1,233 @@
+#include "file_internal.h"
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define FLAG_LEFT   0x01
+#define FLAG_PLUS   0x02
+#define FLAG_SPACE  0x04
+#define FLAG_ZERO   0x08
+#define FLAG_HASH   0x10
+
+typedef enum {
+    LEN_NONE,
+    LEN_HH, LEN_H,
+    LEN_L, LEN_LL,
+    LEN_Z, LEN_T,
+} len_mod_t;
+
+static size_t emit_char(libc_emit_fn emit, void *ctx, char c) {
+    emit(ctx, &c, 1);
+    return 1;
+}
+
+static size_t emit_repeat(libc_emit_fn emit, void *ctx, char c, size_t n) {
+    char buf[32];
+    size_t total = n;
+    while (n > 0) {
+        size_t chunk = n > sizeof(buf) ? sizeof(buf) : n;
+        for (size_t i = 0; i < chunk; i++) buf[i] = c;
+        emit(ctx, buf, chunk);
+        n -= chunk;
+    }
+    return total;
+}
+
+static size_t format_uint(uintmax_t value, unsigned base, int upper, char *out) {
+    const char *digits = upper ? "0123456789ABCDEF" : "0123456789abcdef";
+    char tmp[32];
+    size_t n = 0;
+    if (value == 0) tmp[n++] = '0';
+    while (value > 0) {
+        tmp[n++] = digits[value % base];
+        value /= base;
+    }
+    for (size_t i = 0; i < n; i++) out[i] = tmp[n - 1 - i];
+    return n;
+}
+
+int _libc_vformat(libc_emit_fn emit, void *ctx, const char *fmt, va_list ap) {
+    size_t total = 0;
+
+    while (*fmt) {
+        if (*fmt != '%') {
+            const char *start = fmt;
+            while (*fmt && *fmt != '%') fmt++;
+            size_t n = (size_t)(fmt - start);
+            emit(ctx, start, n);
+            total += n;
+            continue;
+        }
+        fmt++;
+
+        unsigned flags = 0;
+        for (;;) {
+            switch (*fmt) {
+                case '-': flags |= FLAG_LEFT;  fmt++; continue;
+                case '+': flags |= FLAG_PLUS;  fmt++; continue;
+                case ' ': flags |= FLAG_SPACE; fmt++; continue;
+                case '0': flags |= FLAG_ZERO;  fmt++; continue;
+                case '#': flags |= FLAG_HASH;  fmt++; continue;
+            }
+            break;
+        }
+
+        int width = 0;
+        if (*fmt == '*') {
+            width = va_arg(ap, int);
+            if (width < 0) { flags |= FLAG_LEFT; width = -width; }
+            fmt++;
+        } else {
+            while (*fmt >= '0' && *fmt <= '9') {
+                width = width * 10 + (*fmt - '0');
+                fmt++;
+            }
+        }
+
+        int precision = -1;
+        if (*fmt == '.') {
+            fmt++;
+            precision = 0;
+            if (*fmt == '*') {
+                precision = va_arg(ap, int);
+                fmt++;
+            } else {
+                while (*fmt >= '0' && *fmt <= '9') {
+                    precision = precision * 10 + (*fmt - '0');
+                    fmt++;
+                }
+            }
+        }
+
+        len_mod_t len = LEN_NONE;
+        if (*fmt == 'h') {
+            fmt++;
+            if (*fmt == 'h') { len = LEN_HH; fmt++; }
+            else len = LEN_H;
+        } else if (*fmt == 'l') {
+            fmt++;
+            if (*fmt == 'l') { len = LEN_LL; fmt++; }
+            else len = LEN_L;
+        } else if (*fmt == 'z') { len = LEN_Z; fmt++; }
+        else if (*fmt == 't') { len = LEN_T; fmt++; }
+
+        char conv = *fmt;
+        if (conv) fmt++;
+
+        char numbuf[32];
+        size_t numlen = 0;
+        const char *prefix = "";
+        size_t prefix_len = 0;
+
+        switch (conv) {
+            case 'd': case 'i': {
+                intmax_t v;
+                switch (len) {
+                    case LEN_LL: v = va_arg(ap, long long); break;
+                    case LEN_L:  v = va_arg(ap, long); break;
+                    case LEN_Z:  v = (intmax_t)va_arg(ap, size_t); break;
+                    case LEN_T:  v = (intmax_t)va_arg(ap, ptrdiff_t); break;
+                    case LEN_H:  v = (short)va_arg(ap, int); break;
+                    case LEN_HH: v = (signed char)va_arg(ap, int); break;
+                    default:     v = va_arg(ap, int); break;
+                }
+                uintmax_t uv;
+                if (v < 0) {
+                    prefix = "-"; prefix_len = 1;
+                    uv = (uintmax_t)(-(v + 1)) + 1;
+                } else {
+                    uv = (uintmax_t)v;
+                    if (flags & FLAG_PLUS) { prefix = "+"; prefix_len = 1; }
+                    else if (flags & FLAG_SPACE) { prefix = " "; prefix_len = 1; }
+                }
+                numlen = format_uint(uv, 10, 0, numbuf);
+                if (precision >= 0) flags &= ~FLAG_ZERO;
+                break;
+            }
+            case 'u': case 'o': case 'x': case 'X': {
+                uintmax_t uv;
+                switch (len) {
+                    case LEN_LL: uv = va_arg(ap, unsigned long long); break;
+                    case LEN_L:  uv = va_arg(ap, unsigned long); break;
+                    case LEN_Z:  uv = va_arg(ap, size_t); break;
+                    case LEN_T:  uv = (uintmax_t)va_arg(ap, ptrdiff_t); break;
+                    case LEN_H:  uv = (unsigned short)va_arg(ap, unsigned int); break;
+                    case LEN_HH: uv = (unsigned char)va_arg(ap, unsigned int); break;
+                    default:     uv = va_arg(ap, unsigned int); break;
+                }
+                unsigned base = (conv == 'o') ? 8 : (conv == 'u') ? 10 : 16;
+                int upper = (conv == 'X');
+                numlen = format_uint(uv, base, upper, numbuf);
+                if ((flags & FLAG_HASH) && uv != 0) {
+                    if (conv == 'x') { prefix = "0x"; prefix_len = 2; }
+                    else if (conv == 'X') { prefix = "0X"; prefix_len = 2; }
+                    else if (conv == 'o') { prefix = "0"; prefix_len = 1; }
+                }
+                if (precision >= 0) flags &= ~FLAG_ZERO;
+                break;
+            }
+            case 'c': {
+                char c = (char)va_arg(ap, int);
+                int pad = width > 1 ? width - 1 : 0;
+                if (!(flags & FLAG_LEFT)) total += emit_repeat(emit, ctx, ' ', (size_t)pad);
+                total += emit_char(emit, ctx, c);
+                if (flags & FLAG_LEFT) total += emit_repeat(emit, ctx, ' ', (size_t)pad);
+                continue;
+            }
+            case 's': {
+                const char *s = va_arg(ap, const char *);
+                if (!s) s = "(null)";
+                size_t slen = 0;
+                while (s[slen] && (precision < 0 || slen < (size_t)precision)) slen++;
+                int pad = width > (int)slen ? width - (int)slen : 0;
+                if (!(flags & FLAG_LEFT)) total += emit_repeat(emit, ctx, ' ', (size_t)pad);
+                emit(ctx, s, slen); total += slen;
+                if (flags & FLAG_LEFT) total += emit_repeat(emit, ctx, ' ', (size_t)pad);
+                continue;
+            }
+            case 'p': {
+                uintmax_t uv = (uintmax_t)(uintptr_t)va_arg(ap, void *);
+                prefix = "0x"; prefix_len = 2;
+                numlen = format_uint(uv, 16, 0, numbuf);
+                break;
+            }
+            case '%': {
+                total += emit_char(emit, ctx, '%');
+                continue;
+            }
+            case 0: {
+                return (int)total;
+            }
+            default: {
+                total += emit_char(emit, ctx, '%');
+                total += emit_char(emit, ctx, conv);
+                continue;
+            }
+        }
+
+        size_t zeros = 0;
+        if (precision >= 0 && (size_t)precision > numlen) zeros = (size_t)precision - numlen;
+        size_t content = prefix_len + zeros + numlen;
+        size_t spaces = (size_t)width > content ? (size_t)width - content : 0;
+
+        if (!(flags & FLAG_LEFT)) {
+            if (flags & FLAG_ZERO) {
+                emit(ctx, prefix, prefix_len); total += prefix_len;
+                total += emit_repeat(emit, ctx, '0', spaces + zeros);
+                emit(ctx, numbuf, numlen); total += numlen;
+            } else {
+                total += emit_repeat(emit, ctx, ' ', spaces);
+                emit(ctx, prefix, prefix_len); total += prefix_len;
+                total += emit_repeat(emit, ctx, '0', zeros);
+                emit(ctx, numbuf, numlen); total += numlen;
+            }
+        } else {
+            emit(ctx, prefix, prefix_len); total += prefix_len;
+            total += emit_repeat(emit, ctx, '0', zeros);
+            emit(ctx, numbuf, numlen); total += numlen;
+            total += emit_repeat(emit, ctx, ' ', spaces);
+        }
+    }
+
+    return (int)total;
+}

--- a/libc/src/stdio/vfprintf.c
+++ b/libc/src/stdio/vfprintf.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+struct vfprintf_ctx {
+    FILE *stream;
+    int   error;
+};
+
+static void vfprintf_emit(void *vctx, const char *s, size_t n) {
+    struct vfprintf_ctx *c = vctx;
+    FILE *f = c->stream;
+    if (f->backend == FILE_BACKEND_STREAM && f->stream.write) {
+        int rc = f->stream.write(f->stream.ctx, s, n);
+        if (rc < 0) c->error = 1;
+    }
+}
+
+int vfprintf(FILE *stream, const char *fmt, va_list ap) {
+    if (!stream) return -1;
+    struct vfprintf_ctx ctx = { stream, 0 };
+    int n = _libc_vformat(vfprintf_emit, &ctx, fmt, ap);
+    if (ctx.error) {
+        stream->flags |= FILE_FLAG_ERR;
+        return -1;
+    }
+    return n;
+}

--- a/libc/src/stdio/vprintf.c
+++ b/libc/src/stdio/vprintf.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int vprintf(const char *fmt, va_list ap) {
+    return vfprintf(stdout, fmt, ap);
+}

--- a/libc/src/stdio/vsnprintf.c
+++ b/libc/src/stdio/vsnprintf.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include "file_internal.h"
+
+struct snprintf_ctx {
+    char  *buf;
+    size_t size;
+    size_t pos;
+};
+
+static void snprintf_emit(void *vctx, const char *s, size_t n) {
+    struct snprintf_ctx *c = vctx;
+    if (c->size > 0 && c->pos < c->size - 1) {
+        size_t room = c->size - 1 - c->pos;
+        size_t cp = n < room ? n : room;
+        for (size_t i = 0; i < cp; i++) c->buf[c->pos + i] = s[i];
+    }
+    c->pos += n;
+}
+
+int vsnprintf(char *str, size_t size, const char *fmt, va_list ap) {
+    struct snprintf_ctx ctx = { str, size, 0 };
+    int n = _libc_vformat(snprintf_emit, &ctx, fmt, ap);
+    if (size > 0) {
+        size_t term = ctx.pos < size - 1 ? ctx.pos : size - 1;
+        str[term] = '\0';
+    }
+    return n;
+}

--- a/libc/src/stdio/vsprintf.c
+++ b/libc/src/stdio/vsprintf.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <stddef.h>
+
+int vsprintf(char *str, const char *fmt, va_list ap) {
+    return vsnprintf(str, (size_t)-1, fmt, ap);
+}

--- a/libc/src/stdio/vsscanf.c
+++ b/libc/src/stdio/vsscanf.c
@@ -1,0 +1,108 @@
+#include <stdio.h>
+#include <stddef.h>
+
+static int is_ws(char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+static void skip_ws(const char **s) {
+    while (is_ws(**s)) (*s)++;
+}
+
+int vsscanf(const char *str, const char *fmt, va_list ap) {
+    int count = 0;
+    const char *s = str;
+
+    while (*fmt) {
+        if (is_ws(*fmt)) { skip_ws(&s); fmt++; continue; }
+
+        if (*fmt != '%') {
+            if (*s != *fmt) return count;
+            s++; fmt++;
+            continue;
+        }
+        fmt++;
+
+        int suppress = 0;
+        if (*fmt == '*') { suppress = 1; fmt++; }
+        while (*fmt >= '0' && *fmt <= '9') fmt++;
+
+        char conv = *fmt;
+        if (conv) fmt++;
+
+        if (conv != 'c' && conv != '[' && conv != 'n' && conv != '%') skip_ws(&s);
+
+        switch (conv) {
+            case 'd': case 'i': case 'u': case 'o': case 'x': case 'X': {
+                int sign = 0;
+                if (conv == 'd' || conv == 'i' || conv == 'u') {
+                    if (*s == '+') s++;
+                    else if (*s == '-') { sign = 1; s++; }
+                }
+                int base;
+                if (conv == 'd' || conv == 'u') base = 10;
+                else if (conv == 'o') base = 8;
+                else if (conv == 'x' || conv == 'X') {
+                    base = 16;
+                    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+                } else {
+                    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) { base = 16; s += 2; }
+                    else if (s[0] == '0') base = 8;
+                    else base = 10;
+                }
+                const char *start = s;
+                unsigned long val = 0;
+                while (*s) {
+                    int d;
+                    if (*s >= '0' && *s <= '9') d = *s - '0';
+                    else if (*s >= 'a' && *s <= 'f') d = *s - 'a' + 10;
+                    else if (*s >= 'A' && *s <= 'F') d = *s - 'A' + 10;
+                    else break;
+                    if (d >= base) break;
+                    val = val * base + (unsigned long)d;
+                    s++;
+                }
+                if (s == start) return count;
+                if (!suppress) {
+                    int *p = va_arg(ap, int *);
+                    *p = sign ? -(int)val : (int)val;
+                    count++;
+                }
+                break;
+            }
+            case 's': {
+                const char *start = s;
+                while (*s && !is_ws(*s)) s++;
+                if (s == start) return count;
+                if (!suppress) {
+                    char *p = va_arg(ap, char *);
+                    const char *q = start;
+                    while (q < s) *p++ = *q++;
+                    *p = '\0';
+                    count++;
+                }
+                break;
+            }
+            case 'c': {
+                if (!*s) return count;
+                if (!suppress) {
+                    char *p = va_arg(ap, char *);
+                    *p = *s;
+                    count++;
+                }
+                s++;
+                break;
+            }
+            case '%': {
+                if (*s != '%') return count;
+                s++;
+                break;
+            }
+            case 0:
+                return count;
+            default:
+                return count;
+        }
+    }
+    return count;
+}

--- a/libc/src/sys/mkdir.c
+++ b/libc/src/sys/mkdir.c
@@ -1,0 +1,9 @@
+#include <sys/stat.h>
+#include <errno.h>
+
+int mkdir(const char *path, mode_t mode) {
+    (void)path;
+    (void)mode;
+    errno = EROFS;
+    return -1;
+}


### PR DESCRIPTION
stdio (libc/include/stdio.h + libc/src/stdio/):
  - printf 계열: printf, fprintf, sprintf, snprintf, vprintf, vfprintf, vsprintf, vsnprintf
  - scanf 계열: sscanf, vsscanf (정수 변환 위주, %d/%i/%u/%o/%x/%s/%c)
  - 출력: puts, putchar, fputs, fputc, putc
  - 입력: fgetc, getc, fgets
  - FILE I/O: fopen, fclose, fread, fwrite, fseek, ftell, rewind, fflush
  - 상태: feof, ferror, clearerr, fileno
  - 버퍼: setbuf, setvbuf
  - 파일 관리: remove, rename (EROFS stub)
  - 진단: perror
  - 인프라:
      file_internal.h    : struct _FILE 본체 (MEMORY/STREAM 2-backend)
      vformat.c          : printf 계열의 공통 코어 (%d/i/u/o/x/X/c/s/p/% + flags/width/precision/length)
      module_registry.c  : libc_register_module/libc_lookup_module (GRUB module → fopen 백엔드)
      stdio_init.c       : stdin/stdout/stderr 정의, serial_write_char로 출력 흘려보냄

errno (libc/include/errno.h 사용 + libc/src/errno.c):
  - int errno 변수 정의

sys (libc/include/sys/stat.h + libc/src/sys/mkdir.c):
  - mkdir(path, mode): EROFS stub (파일시스템 없음)
  - sys/stat.h에 mkdir/stat prototype 추가

설계 원칙:
  - DOOM 소스 무수정 — fopen("doom.wad", "rb") 호출은 그대로, 우리 fopen이 libc_lookup_module로 GRUB 모듈 메모리를 찾아 MEMORY 백엔드 FILE*을 반환
  - 커널 측은 multiboot2 module 태그를 파싱해 libc_register_module(name, base, size)만 호출하면 됨