### PR TITLE
refactor: pit tic counter 추가

### DIFF
--- a/include/kernel/pit.h
+++ b/include/kernel/pit.h
@@ -6,4 +6,8 @@
 void pit_init(uint32_t freq);
 void pit_set_frequency(uint32_t freq);
 
+// DOOM 포팅을 위한 틱 발생기
+void pit_tick(void);
+uint64_t pit_get_ticks(void);
+
 #endif

--- a/kernel/irq.c
+++ b/kernel/irq.c
@@ -3,16 +3,19 @@
 #include <drivers/serial.h>
 #include <kernel/pit.h>
 
-static void timer_handler(interrupt_frame_t *f)
-{
-    (void)f;
-    serial_write(".");
+static void timer_handler(interrupt_frame_t *f) {
+	(void)f;
+	// serial_write("."); 제거
+	pit_tick();
 }
 
-void irq_init(void)
-{
-    pit_init(100);
+void irq_init(void) {
+	pit_init(1000);
+	/* 100 -> 1000으로 변경
+	 * 1000으로 변경할 경우 timer_handler의 serial_write가
+	 * 부하를 일으킬 것으로 예상되어 serial_write 제거
+	 */
 
-    interrupt_register(32, timer_handler);
-    interrupt_register(33, keyboard_handler);
+	interrupt_register(32, timer_handler);
+	interrupt_register(33, keyboard_handler);
 }

--- a/kernel/pit.c
+++ b/kernel/pit.c
@@ -6,6 +6,24 @@
 #define PIT_COMMAND 0x43
 #define PIT_CHANNEL0 0x40
 
+/*
+ * DOOM 포팅을 위해 변수와 함수 추가
+ * 더 이상 타이머 인터럽트로 인해 터미널에
+ * '.'을 출력하지 않고 pit_ticks를 증가시킴
+ */
+static volatile uint64_t pit_ticks = 0;
+
+void pit_tick(void)
+{
+    pit_ticks++;
+}
+
+uint64_t pit_get_ticks(void)
+{
+    return pit_ticks;
+}
+// 여기까지
+
 static uint16_t pit_compute_divisor(uint32_t freq)
 {
     if (freq == 0)


### PR DESCRIPTION
- 기존에 있던 irq.c의 timer_handler에서 serial_write로 "."을 출력하던 것을 없애고 대신 pit.c의 pit_tick()을 호출하여 pit.c의 pit_ticks 변수를 증가시키도록 변경