### PR TITLE
feature: add key event queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ ISODIR := isodir
 # source layout
 # ---------------------------------
 # Kernel side (everything except libc impls and doom)
-KSRC_DIRS := arch drivers init kernel mm
+# glue = doomgeneric <-> 커널 플랫폼 훅 (커널 헤더 + doomgeneric.h 둘 다 본다)
+KSRC_DIRS := arch drivers init kernel mm glue
 # libc impl
 LSRC_DIR  := libc/src
 # DOOM
@@ -101,6 +102,11 @@ $(BUILD)/kernel.elf: $(OBJS)
 $(BUILD)/doom/%.o: doom/%.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(DOOM_INC) $(DOOM_CFLAGS) -c $< -o $@
+
+# glue (doomgeneric 플랫폼 훅): 커널 헤더 + doomgeneric.h 둘 다 필요해 -I doom 추가
+$(BUILD)/glue/%.o: glue/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(KERNEL_INC) -I doom -c $< -o $@
 
 # libc impls
 $(BUILD)/libc/%.o: libc/%.c

--- a/drivers/input/keyboard.c
+++ b/drivers/input/keyboard.c
@@ -46,6 +46,45 @@ static ring_buffer_t rb;
 static uint8_t shift_pressed	= 0;
 static uint8_t caps_lock	= 0;
 
+// === DOOM용 raw 키 이벤트 큐 ===
+// shell이 쓰는 위 ASCII 큐(rb)와 별개.
+// 누름/뗌 양쪽 + 확장키(0xE0)까지 모두 담아 DOOM의 DG_GetKey가 폴링한다.
+typedef struct key_event {
+	uint8_t scancode;	// release 비트(0x80) 뗀 7-bit set 1 스캔코드
+	uint8_t pressed;	// 1 = 눌림(down), 0 = 뗌(up)
+	uint8_t extended;	// 1 = 직전에 0xE0 prefix가 온 키 (방향키/RCtrl 등)
+} key_event_t;
+
+// 2의 거듭제곱(& 마스크용). 폴링 지연 대비 넉넉한 버퍼 깊이 — 자판 수와 무관
+#define KEY_EVENT_QUEUE_SIZE 256
+static key_event_t ev_buf[KEY_EVENT_QUEUE_SIZE];
+static uint16_t ev_head = 0;
+static uint16_t ev_tail = 0;
+
+// 다음 인터럽트의 스캔코드가 확장(0xE0)임을 표시
+static uint8_t extended_pending = 0;
+
+static void key_event_enqueue(uint8_t scancode, uint8_t pressed, uint8_t extended) {
+	uint16_t next = (ev_tail + 1) & (KEY_EVENT_QUEUE_SIZE - 1);
+	if (next == ev_head) return;	// 가득 참 → 버림
+
+	ev_buf[ev_tail].scancode = scancode;
+	ev_buf[ev_tail].pressed  = pressed;
+	ev_buf[ev_tail].extended = extended;
+	ev_tail = next;
+}
+
+int keyboard_poll_event(uint8_t *scancode, uint8_t *pressed, uint8_t *extended) {
+	if (ev_head == ev_tail) return 0;	// 빈 큐
+
+	*scancode = ev_buf[ev_head].scancode;
+	*pressed  = ev_buf[ev_head].pressed;
+	*extended = ev_buf[ev_head].extended;
+	ev_head = (ev_head + 1) & (KEY_EVENT_QUEUE_SIZE - 1);
+	return 1;
+}
+// 키보드 회사에서 어떤 키를 누르면 어떤 신호를 보내겠다는 규약이 정해져 있음
+// Keyboard Scan Codes: Set 1
 static const char keyboard_map[] = {
 	0, ESC, '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', '\b',
 	'\t', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '[', ']', '\n',
@@ -135,15 +174,36 @@ void keyboard_handler(interrupt_frame_t *f) {
 	// interrupt.h에서 선언한 인터럽트 핸들러 규격 때문에 무조건 넣어야 함
 	(void)f;	// 대신 아무것도 안 하도록 결과값이 없는 void형으로 형 변환
 
-	uint8_t scancode = inb(0x60);	// 0x60 포트에서 스캔코드 추출
+	uint8_t code = inb(0x60);	// 0x60 포트에서 스캔코드 추출
+
+	// 지금 입력된 키가 확장 키임을 알려주는 코드(0xE0) → 다음 바이트가 진짜 키라는 사실만 표시하고 끝
+	// 이렇게 하는 이유는 확장 키가 기존의 스캔 코드를 중복하여 사용하기 떄문
+	// 왼쪽 방향키 = E0 4B
+	// 오른쪽 숫자 키패드 4 = 4B
+	if (code == 0xE0) {
+		extended_pending = 1;
+		return;
+	}
+
+	uint8_t pressed  = !(code & 0x80);	// (code & 0x80)이 1이면 떼진 것(up)
+	uint8_t scancode = code & 0x7F;		// release 비트를 제거한 순수 7-bit 데이터 코드
+	uint8_t extended = extended_pending;	// 위에서 E0가 인식됐으면 확장키라는 상태를 저장
+	extended_pending = 0;
+
+	// raw 이벤트 큐 — 모든 키, 누름/뗌 양쪽 다 적재
+	key_event_enqueue(scancode, pressed, extended);
+
+	// 일반 ASCII 경로 — 확장키(방향키 등)는 제외하고 shell의 기존 동작 유지를 위한 경로. 확장키는 DOOM에서 사용(방향키 등)
+	if (extended)
+		return;
 
 	// 키가 떼졌을 때
-	if (scancode & 0x80) {
+	if (!pressed) {
 		// 그 키가 L_SHIFT나 R_SHIFT일 때
-		if (scancode == (0x2A | 0x80) || scancode == (0x36 | 0x80))
+		if (scancode == 0x2A || scancode == 0x36)
 			shift_pressed = 0;
 		return;
-	}	
+	}
 
 	// 눌린 키가 L_SHIFT나 R_SHIFT일 때
 	if (scancode == 0x2A || scancode == 0x36) {
@@ -167,8 +227,4 @@ void keyboard_handler(interrupt_frame_t *f) {
 		char buf[2] = {c, 0};
 		serial_write(buf);
 	}
-
-	// pic_send_eoi() 함수가 자동으로 처리해줌
-	// 그래서 outb(0x20, 0x20)를 따로 해줄 필요가 없음
-	// outb(0x20, 0x20);
 }

--- a/drivers/input/keyboard.c
+++ b/drivers/input/keyboard.c
@@ -48,9 +48,9 @@ static uint8_t caps_lock	= 0;
 
 // === DOOM용 raw 키 이벤트 큐 ===
 // shell이 쓰는 위 ASCII 큐(rb)와 별개.
-// 누름/뗌 양쪽 + 확장키(0xE0)까지 모두 담아 DOOM의 DG_GetKey가 폴링한다.
+// 누름/뗌 양쪽 + 확장키(0xE0)까지 모두 저장
 typedef struct key_event {
-	uint8_t scancode;	// release 비트(0x80) 뗀 7-bit set 1 스캔코드
+	uint8_t scancode;	// 최상위 비트인 release 비트를 떼고 순수한 7-bit 크기의 스캔코드
 	uint8_t pressed;	// 1 = 눌림(down), 0 = 뗌(up)
 	uint8_t extended;	// 1 = 직전에 0xE0 prefix가 온 키 (방향키/RCtrl 등)
 } key_event_t;

--- a/drivers/tty/console_driver.c
+++ b/drivers/tty/console_driver.c
@@ -60,6 +60,12 @@ void console_readline() {
 	} while (1);
 }
 
+// 직전 console_readline()이 받은 입력 줄(NULL 종료)을 돌려줌.
+// shell이 명령어를 구분하려면 사용자가 친 줄을 읽어야 함.
+const char* console_get_line(void) {
+	return g_line_buf;
+}
+
 void console_putchar(char c, uint32_t font_color, uint32_t bg_color, uint32_t scale) {
 	fb_write_char(cursor.x, cursor.y, c, font_color, bg_color, scale);
 }

--- a/drivers/tty/mini_shell.c
+++ b/drivers/tty/mini_shell.c
@@ -2,7 +2,9 @@
 #include <drivers/font.h>
 #include <drivers/framebuffer.h>
 #include <drivers/mini_shell.h>
+#include <doomgeneric_minidos.h>
 #include <stdint.h>
+#include <string.h>
 
 uint32_t system_font_color;
 uint32_t system_bg_color;
@@ -29,6 +31,10 @@ void shell_wait() {
 
 	// 사용자 입력
 	console_readline();
+
+	// 명령어[1]: doom 실행
+	if (strcmp(console_get_line(), "doom") == 0)
+		doom_run();
 }
 
 void shell_init() {

--- a/glue/doomgeneric_minidos.c
+++ b/glue/doomgeneric_minidos.c
@@ -1,0 +1,170 @@
+// doomgeneric <-> mini-dOS 플랫폼 glue
+//
+// doomgeneric.h가 "Implement below functions for your platform"로 남겨둔
+// 6개 DG_* 훅을 mini-dOS 커널 서비스에 연결한다.
+//   - 타이머 : PIT(1000Hz) tick  -> DG_GetTicksMs / DG_SleepMs
+//   - 입력   : 키 이벤트 큐       -> DG_GetKey
+//   - 화면   : 프레임버퍼         -> DG_Init / DG_DrawFrame
+//
+// DOOM 소스(doom/)는 -I libc/include -I doom 로 커널과 격리돼 있으므로
+// 이 파일은 *커널 쪽*(glue/)에 두어 커널 헤더와 doomgeneric.h를 동시에 본다.
+
+#include <stdint.h>
+
+#include <drivers/framebuffer.h>
+#include <drivers/keyboard.h>
+#include <drivers/serial.h>
+#include <kernel/pit.h>
+
+#include "doomgeneric.h"
+#include "doomkeys.h"
+
+#include <doomgeneric_minidos.h>
+
+// ---------------------------------------------------------------------------
+// A. 타이머  (PIT @ 1000Hz 라서 1 tick == 1ms)
+// ---------------------------------------------------------------------------
+uint32_t DG_GetTicksMs(void) {
+	return (uint32_t)pit_get_ticks();
+}
+
+void DG_SleepMs(uint32_t ms) {
+	uint64_t start = pit_get_ticks();
+	// 인터럽트가 켜진 상태(쉘 컨텍스트)에서 tick이 진행되므로 hlt로 대기
+	while ((pit_get_ticks() - start) < (uint64_t)ms)
+		__asm__ __volatile__("hlt");
+}
+
+// ---------------------------------------------------------------------------
+// C. 화면 출력
+//   DG_ScreenBuffer: 640x400, 32bpp 0xAARRGGBB (i_video.c rgba8888 모드)
+//   fb_paint_pixel의 color 인자와 바이트 레이아웃이 동일해 그대로 복사 가능.
+// ---------------------------------------------------------------------------
+void DG_Init(void) {
+	fb_clear(0x00000000);
+}
+
+void DG_DrawFrame(void) {
+	const uint32_t fbw = fb_get_width();
+	const uint32_t fbh = fb_get_height();
+
+	// HW 프레임버퍼가 DOOM 해상도보다 크면 가운데 정렬, 작으면 클리핑
+	const uint32_t cw = fbw < DOOMGENERIC_RESX ? fbw : DOOMGENERIC_RESX;
+	const uint32_t ch = fbh < DOOMGENERIC_RESY ? fbh : DOOMGENERIC_RESY;
+	const uint32_t ox = (fbw - cw) / 2;
+	const uint32_t oy = (fbh - ch) / 2;
+
+	if (fb_get_bpp() == 32) {
+		// 빠른 경로: 행 단위 32비트 직접 복사
+		uint8_t *base    = fb_get_base();
+		uint32_t pitch   = fb_get_pitch();
+		for (uint32_t y = 0; y < ch; y++) {
+			uint32_t *dst       = (uint32_t *)(base + (uint64_t)(oy + y) * pitch + (uint64_t)ox * 4);
+			const pixel_t *src  = DG_ScreenBuffer + (uint64_t)y * DOOMGENERIC_RESX;
+			for (uint32_t x = 0; x < cw; x++)
+				dst[x] = src[x];
+		}
+	} else {
+		// 일반 경로: bpp 변환은 fb_paint_pixel에 위임
+		for (uint32_t y = 0; y < ch; y++) {
+			const pixel_t *src = DG_ScreenBuffer + (uint64_t)y * DOOMGENERIC_RESX;
+			for (uint32_t x = 0; x < cw; x++)
+				fb_paint_pixel(ox + x, oy + y, (uint32_t)src[x]);
+		}
+	}
+}
+
+void DG_SetWindowTitle(const char *title) {
+	if (!title) return;
+	serial_write("[doom] ");
+	serial_write(title);
+	serial_write("\r\n");
+}
+
+// ---------------------------------------------------------------------------
+// B. 입력
+//   keyboard_poll_event()가 PS/2 scancode set 1의 make 코드(release 비트 제거),
+//   pressed, extended(0xE0 prefix) 를 돌려준다. 이를 DOOM 키코드로 변환.
+// ---------------------------------------------------------------------------
+
+// 비확장(non-0xE0) make 코드 -> DOOM 키코드. 0 = 매핑 없음(무시).
+static const unsigned char s_base_map[128] = {
+	[0x01] = KEY_ESCAPE,
+	[0x02] = '1', [0x03] = '2', [0x04] = '3', [0x05] = '4', [0x06] = '5',
+	[0x07] = '6', [0x08] = '7', [0x09] = '8', [0x0A] = '9', [0x0B] = '0',
+	[0x0C] = KEY_MINUS, [0x0D] = KEY_EQUALS,
+	[0x0E] = KEY_BACKSPACE,
+	[0x0F] = KEY_TAB,
+	[0x10] = 'q', [0x11] = 'w', [0x12] = 'e', [0x13] = 'r', [0x14] = 't',
+	[0x15] = 'y', [0x16] = 'u', [0x17] = 'i', [0x18] = 'o', [0x19] = 'p',
+	[0x1A] = '[', [0x1B] = ']',
+	[0x1C] = KEY_ENTER,
+	[0x1D] = KEY_FIRE,			// Left Ctrl   -> 발사
+	[0x1E] = 'a', [0x1F] = 's', [0x20] = 'd', [0x21] = 'f', [0x22] = 'g',
+	[0x23] = 'h', [0x24] = 'j', [0x25] = 'k', [0x26] = 'l',
+	[0x27] = ';', [0x28] = '\'', [0x29] = '`',
+	[0x2A] = KEY_RSHIFT,			// Left Shift  -> 달리기
+	[0x2B] = '\\',
+	[0x2C] = 'z', [0x2D] = 'x', [0x2E] = 'c', [0x2F] = 'v', [0x30] = 'b',
+	[0x31] = 'n', [0x32] = 'm',
+	[0x33] = ',', [0x34] = '.', [0x35] = '/',
+	[0x36] = KEY_RSHIFT,			// Right Shift -> 달리기
+	[0x37] = KEYP_MULTIPLY,
+	[0x38] = KEY_LALT,			// Left Alt    -> 옆걸음(strafe)
+	[0x39] = KEY_USE,			// Space       -> 사용/문열기
+	[0x3A] = KEY_CAPSLOCK,
+	[0x3B] = KEY_F1,  [0x3C] = KEY_F2,  [0x3D] = KEY_F3,  [0x3E] = KEY_F4,
+	[0x3F] = KEY_F5,  [0x40] = KEY_F6,  [0x41] = KEY_F7,  [0x42] = KEY_F8,
+	[0x43] = KEY_F9,  [0x44] = KEY_F10,
+	// 키패드 (NumLock off 시 방향키로도 쓰이지만 기본 매핑만 제공)
+	[0x47] = KEY_HOME,     [0x48] = KEY_UPARROW,   [0x49] = KEY_PGUP,
+	[0x4B] = KEY_LEFTARROW,[0x4D] = KEY_RIGHTARROW,
+	[0x4F] = KEY_END,      [0x50] = KEY_DOWNARROW, [0x51] = KEY_PGDN,
+	[0x52] = KEY_INS,      [0x53] = KEY_DEL,
+};
+
+static unsigned char translate(uint8_t sc, uint8_t ext) {
+	if (ext) {
+		// 0xE0 확장: 메인 방향키/내비게이션 및 우측 수정자 키
+		switch (sc) {
+			case 0x48: return KEY_UPARROW;
+			case 0x50: return KEY_DOWNARROW;
+			case 0x4B: return KEY_LEFTARROW;
+			case 0x4D: return KEY_RIGHTARROW;
+			case 0x1D: return KEY_FIRE;		// Right Ctrl
+			case 0x38: return KEY_RALT;		// Right Alt
+			case 0x1C: return KEY_ENTER;		// 키패드 Enter
+			case 0x47: return KEY_HOME;
+			case 0x4F: return KEY_END;
+			case 0x49: return KEY_PGUP;
+			case 0x51: return KEY_PGDN;
+			case 0x52: return KEY_INS;
+			case 0x53: return KEY_DEL;
+			default:   return 0;
+		}
+	}
+	if (sc < 128) return s_base_map[sc];
+	return 0;
+}
+
+int DG_GetKey(int *pressed, unsigned char *key) {
+	uint8_t sc, pr, ext;
+	while (keyboard_poll_event(&sc, &pr, &ext)) {
+		unsigned char k = translate(sc, ext);
+		if (!k) continue;		// 매핑 안 된 키는 건너뛰고 다음 이벤트
+		*pressed = pr;
+		*key     = k;
+		return 1;
+	}
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// 진입점
+//   doomgeneric_Create() -> D_DoomMain() 내부 게임 루프로 진입하며 보통 복귀하지
+//   않는다. (실제 구동에는 IWAD가 libc 모듈로 등록돼 있어야 한다 — 후속 작업.)
+// ---------------------------------------------------------------------------
+void doom_run(void) {
+	char *argv[] = { "doom" };
+	doomgeneric_Create(1, argv);
+}

--- a/include/doomgeneric_minidos.h
+++ b/include/doomgeneric_minidos.h
@@ -1,0 +1,7 @@
+#ifndef DOOMGENERIC_MINIDOS_H
+#define DOOMGENERIC_MINIDOS_H
+
+// doomgeneric 게임 루프 진입. 보통 복귀하지 않는다.
+void doom_run(void);
+
+#endif

--- a/include/drivers/console_driver.h
+++ b/include/drivers/console_driver.h
@@ -13,6 +13,7 @@ typedef struct cursor {
 extern cursor_t cursor;
 
 void console_readline();
+const char* console_get_line(void);
 void console_putchar(char c, uint32_t font_color, uint32_t bg_color, uint32_t scale);
 void console_puts(uint32_t x, uint32_t y, const char* str, uint32_t font_color, uint32_t bg_color, uint32_t scale);
 void console_setter(uint32_t font_color, uint32_t bg_color, uint32_t scale);

--- a/include/drivers/keyboard.h
+++ b/include/drivers/keyboard.h
@@ -2,8 +2,13 @@
 #define KEYBOARD_H
 
 #include <asm/interrupt.h>
+#include <stdint.h>
 
 char keyboard_dequeue();
 void keyboard_handler(interrupt_frame_t *f);
+
+// DOOM용 raw 키 이벤트 폴링
+// 이벤트가 있으면 1을 반환하며 out 파라미터를 채우고, 없으면 0
+int keyboard_poll_event(uint8_t *scancode, uint8_t *pressed, uint8_t *extended);
 
 #endif


### PR DESCRIPTION
feat: DOOM 포팅을 위한 Key Event Queue 추가
- shell의 입력만을 위한 ring buffer 외에 DOOM 게임 플레이를 위해 키 이벤트들을 저장할 Key Event Queue와 이벤트 구조체 추가
- 이벤트 구조체:
  - release 비트인 최상위 비트를 뗀 7비트 크기의 순수 scancode
  - 키가 눌린 상태인지 떼진 상태인지를 저장하는 pressed
  - 스캔코드 E0가 붙은 확장키인지 상태를 저장하는 extended
- 하지만 현재 우려되는 점은 ring buffer와 key event queue가 독립적으로 작동한다는 것
  - ring buffer는 shell에서만 사용하고 key event queue는 DOOM에서만 사용
  - 그렇지만 두 버퍼 모두 키 입력에 대해 데이터를 저장
  - 만약 shell에서 여러 입력을 한 후 DOOM을 실행하면 이전에 key event queue에 쌓인 데이터가 와르르 입력될 수 있고
  - DOOM 실행이 끝난 후 shell로 돌아왔을 때에도 게임을 실행하면서 입력했던 키들이 shell에 와르르 입력될 수 있음