### PR TITLE
bugfix: doom 종료 후 콘솔 화면으로 돌아가지 않던 문제 해결

### DIFF
--- a/doom/i_system.c
+++ b/doom/i_system.c
@@ -243,26 +243,44 @@ void I_BindVariables(void)
 // I_Quit
 //
 
+// ===== AI-GENERATED (Claude) BEGIN =====
+// mini-dOS 포팅: DOOM에는 프로세스 모델이 없어 원래의 exit(0)은 머신을 정지시킨다.
+// 대신 호스트 게임 루프(glue의 doom_run)에 "종료 요청" 플래그만 올리고 즉시 복귀한다.
+// 여기서 exit_funcs(예: I_ShutdownGraphics → Z_Free(I_VideoBuffer))를 돌리면, 아직
+// 진행 중이던 현재 틱의 나머지(D_Display 등)가 해제된 버퍼를 건드리므로 돌리지 않는다.
+// 실제 정리는 doom_run이 루프를 빠져나온 뒤 I_DoomShutdown()에서 한 번에 수행한다.
 void I_Quit (void)
 {
-    atexit_listentry_t *entry;
+    extern volatile int dg_quit_requested;
+    dg_quit_requested = 1;
+}
 
-    // Run through all exit functions
- 
-    entry = exit_funcs; 
-
+// mini-dOS 포팅: DOOM 종료 후 셸 복귀 및 "doom" 재실행을 위한 1회 teardown.
+// DOOM 런타임 상태의 대부분은 zone(mainzone) 안에 할당되므로 zone을 통째로 해제하면
+// 그 안의 모든 것(I_VideoBuffer 포함)이 사라진다. zone 밖에서 실행마다 누적되는 전역만
+// 따로 리셋한다: atexit 리스트와 WAD 디렉터리(lumpinfo/numlumps).
+void I_DoomShutdown (void)
+{
+    // 1) atexit 리스트 비우기 — 매 실행마다 누적되고, 다음 실행 땐 해제된 zone을 가리킨다.
+    atexit_listentry_t *entry = exit_funcs;
     while (entry != NULL)
     {
-        entry->func();
-        entry = entry->next;
+        atexit_listentry_t *next = entry->next;
+        free (entry);
+        entry = next;
     }
+    exit_funcs = NULL;
 
-#if ORIGCODE
-    SDL_Quit();
+    // 2) WAD 디렉터리 리셋 — lumpinfo(append-realloc)와 lumphash(이전 zone의 stale
+    //    포인터)를 비운다. lumphash를 안 비우면 다음 W_AddFile이 그걸 Z_Free하다가
+    //    "freed a pointer without ZONEID"로 죽는다. W가 자기 static을 소유하므로 위임한다.
+    W_Shutdown ();
 
-    exit(0);
-#endif
+    // 3) zone 통째 해제 — I_VideoBuffer 등 zone 내부 할당이 전부 함께 사라진다.
+    Z_Shutdown ();
+    I_VideoBuffer = NULL;   // zone과 함께 해제됨; 다음 실행의 I_InitGraphics 전까지 dangling 방지
 }
+// ===== AI-GENERATED (Claude) END ======
 
 #if !defined(_WIN32) && !defined(__MACOSX__) && !defined(__DJGPP__)
 #define ZENITY_BINARY "/usr/bin/zenity"

--- a/doom/i_system.h
+++ b/doom/i_system.h
@@ -80,5 +80,9 @@ void I_PrintBanner(char *text);
 
 void I_PrintDivider(void);
 
+// mini-dOS 포팅: DOOM 종료 후 셸 복귀 및 "doom" 재실행을 위한 1회 teardown.
+// zone/lumpinfo/atexit 등 실행마다 누적되는 상태를 해제한다.
+void I_DoomShutdown(void);
+
 #endif
 

--- a/doom/w_wad.c
+++ b/doom/w_wad.c
@@ -569,6 +569,26 @@ void W_GenerateHashTable(void)
     // All done!
 }
 
+// ===== AI-GENERATED (Claude) BEGIN =====
+// mini-dOS 포팅: DOOM 재실행을 위해 WAD 디렉터리 상태를 비운다.
+//   - lumpinfo : realloc으로 잡힌 일반 힙 → free 후 NULL.
+//   - lumphash : 이전 zone(Z_Malloc)에 있던 해시테이블 → zone 통째 해제와 함께
+//                이미 사라졌으므로 free하지 않고 포인터만 NULL로 둔다. 이 NULL화를
+//                빠뜨리면 다음 실행의 W_AddFile이 stale 포인터를 Z_Free →
+//                "Z_Free: freed a pointer without ZONEID"로 죽는다.
+//   - numlumps : 0으로 되돌려 다음 W_AddFile이 처음부터 적재하게 한다.
+void W_Shutdown(void)
+{
+    if (lumpinfo != NULL)
+    {
+        free(lumpinfo);
+        lumpinfo = NULL;
+    }
+    numlumps = 0;
+    lumphash = NULL;
+}
+// ===== AI-GENERATED (Claude) END ======
+
 // Lump names that are unique to particular game types. This lets us check
 // the user is not trying to play with the wrong executable, eg.
 // chocolate-doom -iwad hexen.wad.

--- a/doom/w_wad.h
+++ b/doom/w_wad.h
@@ -75,4 +75,7 @@ void    W_ReleaseLumpName(char *name);
 
 void W_CheckCorrectIWAD(GameMission_t mission);
 
+// mini-dOS 포팅: WAD 디렉터리 상태(lumpinfo/lumphash/numlumps)를 리셋해 재실행을 가능케 한다.
+void W_Shutdown(void);
+
 #endif

--- a/doom/z_zone.c
+++ b/doom/z_zone.c
@@ -17,6 +17,8 @@
 //
 
 
+#include <stdlib.h>
+
 #include "z_zone.h"
 #include "i_system.h"
 #include "doomtype.h"
@@ -118,6 +120,21 @@ void Z_Init (void)
     
     block->size = mainzone->size - sizeof(memzone_t);
 }
+
+
+// ===== AI-GENERATED (Claude) BEGIN =====
+// mini-dOS 포팅: zone 베이스(mainzone)는 I_ZoneBase가 malloc으로 잡은 단일 블록이라
+// 통째로 free하면 zone 안의 모든 할당이 한 번에 사라진다. DOOM 종료 후 셸로 복귀하고
+// "doom"을 다시 실행할 때, 다음 Z_Init이 새 zone을 잡기 전에 헌 zone을 해제해 누수를 막는다.
+void Z_Shutdown (void)
+{
+    if (mainzone != NULL)
+    {
+        free (mainzone);
+        mainzone = NULL;
+    }
+}
+// ===== AI-GENERATED (Claude) END ======
 
 
 //

--- a/doom/z_zone.h
+++ b/doom/z_zone.h
@@ -62,6 +62,10 @@ void    Z_ChangeUser(void *ptr, void **user);
 int     Z_FreeMemory (void);
 unsigned int Z_ZoneSize(void);
 
+// mini-dOS 포팅: zone 전체를 해제한다(DOOM 종료 후 재실행을 위해).
+// 다음 Z_Init이 새 zone을 다시 잡는다.
+void    Z_Shutdown (void);
+
 //
 // This is used to get the local FILE:LINE info from CPP
 // prior to really call the function in question.

--- a/drivers/tty/mini_shell.c
+++ b/drivers/tty/mini_shell.c
@@ -191,7 +191,7 @@ void shell_wait() {
 	else if ((args = match_cmd(line, "free"))     != (void*)0) cmd_free(args);
 	else if ((args = match_cmd(line, "reboot"))   != (void*)0) cmd_reboot();
 	else if ((args = match_cmd(line, "poweroff")) != (void*)0) cmd_poweroff();
-	else if (strcmp(line, "doom") == 0) doom_run();
+	else if (strcmp(line, "doom") == 0) { doom_run(); cmd_clear(); }	// DOOM 종료 후 화면(배경색·커서) 복원
 	else shell_println("command not found");
 }
 

--- a/glue/doomgeneric_minidos.c
+++ b/glue/doomgeneric_minidos.c
@@ -10,6 +10,7 @@
 // 이 파일은 *커널 쪽*(glue/)에 두어 커널 헤더와 doomgeneric.h를 동시에 본다.
 
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <drivers/framebuffer.h>
 #include <drivers/keyboard.h>
@@ -191,11 +192,30 @@ int DG_GetKey(int *pressed, unsigned char *key) {
 //   IWAD(doom1.wad)는 부팅 시 GRUB 모듈로 적재되어 libc 모듈 레지스트리에 등록돼
 //   있어야 한다 (kmain의 libc_register_module). -iwad로 그 이름을 지정한다.
 // ---------------------------------------------------------------------------
+// ===== AI-GENERATED (Claude) BEGIN =====
+// 호스트 종료 요청 플래그. DOOM 메뉴 Quit → I_Quit이 1로 올리면 아래 루프가 빠져나온다.
+volatile int dg_quit_requested = 0;
+
 void doom_run(void) {
 	char *argv[] = { "doom", "-iwad", "doom1.wad" };
+
+	dg_quit_requested = 0;			// 재실행 대비 초기화
 	doomgeneric_Create(3, argv);
 
-	// 게임 루프: 호스트가 프레임마다 틱을 돌린다 (복귀하지 않음)
-	for (;;)
+	// 게임 루프: I_Quit이 종료 플래그를 올릴 때까지 매 프레임 틱.
+	// (Quit한 그 틱의 나머지는 아직 살아있는 버퍼 위에서 무해하게 끝나고 복귀한다.)
+	while (!dg_quit_requested)
 		doomgeneric_Tick();
+
+	// ── 종료 정리: 셸로 깨끗이 복귀 + 다음 "doom" 재실행이 가능하도록 ──
+	I_DoomShutdown();			// zone/lumpinfo/atexit 해제 (doom 측 상태)
+	if (DG_ScreenBuffer) {			// glue가 매 실행 malloc하는 프레임 버퍼
+		free(DG_ScreenBuffer);
+		DG_ScreenBuffer = NULL;
+	}
+	while (keyboard_dequeue() != '\0')	// 셸로 새어나갈 잔여 키 입력 비우기
+		;
+	serial_write("[doom] quit -> shell\r\n");	// 종료/복귀 진단 마커
+	// 화면 복원(배경색·커서)은 셸 소관이므로 호출부(mini_shell)가 doom_run 복귀 후 처리한다.
 }
+// ===== AI-GENERATED (Claude) END ======

--- a/include/doomgeneric_minidos.h
+++ b/include/doomgeneric_minidos.h
@@ -1,7 +1,13 @@
 #ifndef DOOMGENERIC_MINIDOS_H
 #define DOOMGENERIC_MINIDOS_H
 
-// doomgeneric 게임 루프 진입. 보통 복귀하지 않는다.
+// doomgeneric 게임 루프 진입. DOOM을 종료(메뉴 Quit)하면 정리 후 셸로 복귀한다.
 void doom_run(void);
+
+// DOOM 종료 요청 플래그. DOOM의 I_Quit이 1로 올리면 doom_run의 게임 루프가 빠져나온다.
+extern volatile int dg_quit_requested;
+
+// DOOM 종료 후 1회 정리(zone/lumpinfo/atexit 해제). doom/i_system.c에 정의.
+void I_DoomShutdown(void);
 
 #endif


### PR DESCRIPTION
[AI 활용]
- I_Quit: exit()로 머신 정지 대신 종료 플래그(dg_quit_requested)만 set
- doom_run: 게임 루프를 종료 플래그로 탈출 가능하게 하고, 복귀 시 잔여 키 입력 드레인
- I_DoomShutdown/Z_Shutdown/W_Shutdown: zone·lumpinfo·lumphash·atexit 리스트를 해제/리셋해 'doom' 재실행 시 stale 포인터 Z_Free(ZONEID 오류) 없이 재초기화

[수정]
- mini_shell: doom 종료 후 cmd_clear()로 화면 배경색과 기본 출력 복원